### PR TITLE
Set page title via command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 apidoc extension Change Log
 -----------------------
 
 - no changes in this release.
-
+- Enh: Added ability to set pageTitle from command line (unclead)
 
 2.0.3 March 01, 2015
 --------------------

--- a/commands/ApiController.php
+++ b/commands/ApiController.php
@@ -50,6 +50,10 @@ class ApiController extends BaseController
         $renderer->apiUrl = './';
         $renderer->guidePrefix = $this->guidePrefix;
 
+        if (!empty($this->pageTitle)) {
+            $renderer->pageTitle = $this->pageTitle;
+        }
+
         // setup reference to guide
         if ($this->guide !== null) {
             $renderer->guideUrl = $guideUrl = $this->guide;

--- a/commands/GuideController.php
+++ b/commands/GuideController.php
@@ -47,6 +47,9 @@ class GuideController extends BaseController
             return 1;
         }
 
+        if (!empty($this->pageTitle)) {
+            $renderer->pageTitle = $this->pageTitle;
+        }
         if ($renderer->guideUrl === null) {
             $renderer->guideUrl = './';
         }

--- a/components/BaseController.php
+++ b/components/BaseController.php
@@ -25,11 +25,16 @@ abstract class BaseController extends Controller
      * @var string template to use for rendering
      */
     public $template = 'bootstrap';
+
     /**
      * @var string|array files to exclude.
      */
     public $exclude;
 
+    /**
+     * @var string page title
+     */
+    public $pageTitle;
 
     /**
      * Checks that target directory is valid. Asks questions in tricky cases.
@@ -156,6 +161,6 @@ abstract class BaseController extends Controller
      */
     public function options($actionID)
     {
-        return array_merge(parent::options($actionID), ['template', 'exclude']);
+        return array_merge(parent::options($actionID), ['template', 'exclude', 'pageTitle']);
     }
 }

--- a/renderers/BaseRenderer.php
+++ b/renderers/BaseRenderer.php
@@ -38,6 +38,8 @@ abstract class BaseRenderer extends Component
 
     public $guidePrefix = 'guide-';
     public $apiUrl;
+    public $pageTitle;
+
     /**
      * @var Context the [[Context]] currently being rendered.
      */


### PR DESCRIPTION
implemented the ability to setting page title from command line

```
vendor/bin/apidoc guide source ./output  --interactive=0 --pageTitle='Test page title'
```