### PR TITLE
json and external templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.idea
 /vendor
-/output
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /vendor
-composer.lock
+/output

--- a/commands/ApiController.php
+++ b/commands/ApiController.php
@@ -151,6 +151,10 @@ class ApiController extends BaseController
      */
     protected function findRenderer($template)
     {
+        if (class_exists($template)) {
+            return new $template();
+        }
+
         $rendererClass = 'yii\\apidoc\\templates\\' . $template . '\\ApiRenderer';
         if (!class_exists($rendererClass)) {
             $this->stderr('Renderer not found.' . PHP_EOL);

--- a/templates/json/ApiRenderer.php
+++ b/templates/json/ApiRenderer.php
@@ -15,8 +15,8 @@ use Yii;
 /**
  * The class for outputting documentation data structures as a JSON text.
  *
- * @author Carsten Brandt <mail@cebe.cc>
- * @since 2.0
+ * @author Tom Worster <fsb@thefsb.org>
+ * @since 2.0.5
  */
 class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
 {

--- a/templates/json/ApiRenderer.php
+++ b/templates/json/ApiRenderer.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\apidoc\templates\json;
+
+use yii\apidoc\models\Context;
+use yii\apidoc\renderers\ApiRenderer as BaseApiRenderer;
+use yii\base\ViewContextInterface;
+use yii\helpers\Html;
+use yii\web\View;
+use Yii;
+
+/**
+ * The class for outputting documentation data structures as a JSON text.
+ *
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @since 2.0
+ */
+class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
+{
+
+    /**
+     * Writes a given [[Context]] as JSON text to file 'types.json'.
+     *
+     * @param Context $context the api documentation context to render.
+     * @param $targetDir
+     */
+    public function render($context, $targetDir)
+    {
+        $types = array_merge($context->classes, $context->interfaces, $context->traits);
+        file_put_contents($targetDir . '/types.json', json_encode($types, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function generateApiUrl($typeName)
+    {
+        return $this->generateFileName($typeName);
+    }
+
+    /**
+     * Generates file name for API page for a given type
+     * @param string $typeName
+     * @return string
+     */
+    protected function generateFileName($typeName)
+    {
+        return strtolower(str_replace('\\', '-', $typeName)) . '.html';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getViewPath()
+    {
+        return Yii::getAlias('@yii/apidoc/templates/html/views');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function generateLink($text, $href, $options = [])
+    {
+        $options['href'] = $href;
+
+        return Html::a($text, null, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSourceUrl($type, $line = null)
+    {
+        return null;
+    }
+}

--- a/templates/json/ApiRenderer.php
+++ b/templates/json/ApiRenderer.php
@@ -10,8 +10,6 @@ namespace yii\apidoc\templates\json;
 use yii\apidoc\models\Context;
 use yii\apidoc\renderers\ApiRenderer as BaseApiRenderer;
 use yii\base\ViewContextInterface;
-use yii\helpers\Html;
-use yii\web\View;
 use Yii;
 
 /**
@@ -40,17 +38,13 @@ class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
      */
     public function generateApiUrl($typeName)
     {
-        return $this->generateFileName($typeName);
     }
 
     /**
-     * Generates file name for API page for a given type
-     * @param string $typeName
-     * @return string
+     * @inheritdoc
      */
     protected function generateFileName($typeName)
     {
-        return strtolower(str_replace('\\', '-', $typeName)) . '.html';
     }
 
     /**
@@ -58,7 +52,6 @@ class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
      */
     public function getViewPath()
     {
-        return Yii::getAlias('@yii/apidoc/templates/html/views');
     }
 
     /**
@@ -66,9 +59,6 @@ class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
      */
     protected function generateLink($text, $href, $options = [])
     {
-        $options['href'] = $href;
-
-        return Html::a($text, null, $options);
     }
 
     /**
@@ -76,6 +66,5 @@ class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
      */
     public function getSourceUrl($type, $line = null)
     {
-        return null;
     }
 }


### PR DESCRIPTION
One change dumps the info from docblocks to JSON.

The other allows templates to be outside the extension's root.