### PR TITLE
Limit content image width to 100%

### DIFF
--- a/templates/bootstrap/assets/css/style.css
+++ b/templates/bootstrap/assets/css/style.css
@@ -7,6 +7,10 @@ body {
     max-width: 1250px;
 }
 
+.guide-content img, .api-content img {
+    max-width: 100%;
+}
+
 .wrap {
     min-height: 100%;
     height: auto;


### PR DESCRIPTION
Before fix:
![](https://monosnap.com/file/dgGPfaS91lk2dK2jzwOPkKN3C2RbbG.png)

After fix:
![](https://monosnap.com/file/Vo8lX3mFpjwgdlhkB4CHCyEg7QWID6.png)