### PR TITLE
Context::inheritDocs() fix

### DIFF
--- a/models/Context.php
+++ b/models/Context.php
@@ -221,7 +221,7 @@ class Context extends Component
                 // descriptions will be concatenated.
                 $p->description = trim($p->description) . "\n\n"
                     . trim($inheritedProperty->description) . "\n\n"
-                    . $p->getFirstTag('inheritdoc')->getContent();
+                    . $this->getInheritedContent($p);
 
                 $p->removeTag('inheritdoc');
             }
@@ -248,7 +248,7 @@ class Context extends Component
                 // descriptions will be concatenated.
                 $m->description = trim($m->description) . "\n\n"
                     . trim($inheritedMethod->description) . "\n\n"
-                    . $m->getFirstTag('inheritdoc')->getContent();
+                    . $this->getInheritedContent($m);
 
                 foreach ($m->params as $i => $param) {
                     if (!isset($inheritedMethod->params[$i])) {
@@ -272,6 +272,16 @@ class Context extends Component
                 $m->removeTag('inheritdoc');
             }
         }
+    }
+
+    /**
+     * @param BaseDoc $doc
+     * @return string
+     */
+    protected function getInheritedContent(BaseDoc $doc)
+    {
+        $firstTag = $doc->getFirstTag('inheritdoc');
+        return ($firstTag instanceof BaseDoc) ? $firstTag->getContent() : '';
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |

It is hotfix for:
`$ php ./vendor/bin/apidoc guide ./guide/ ./web/docs/ --interactive=0`
PHP Fatal error:  Call to a member function getContent() on null in /var/www/<...>/vendor/yiisoft/yii2-apidoc/models/Context.php on line 251
when, probably, some @inheritdoc tag missing.

PS: on your "guidelines for contributing" page last link is 404.
