### PR TITLE
Separate warnings and errors occurred on processing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 apidoc extension Change Log
 - Bug #76: Fixed broken links with external urls (CedricYii)
 - Bug #79: Fixed crash due to missing encoding specified in `mb_*` functions (cebe, dingzhihao)
 - Enh #117: Add support for `int` and `bool` types (rob006)
+- Enh #118: Separate warnings and errors occurred on processing files (rob006)
 
 
 2.0.5 March 17, 2016

--- a/commands/ApiController.php
+++ b/commands/ApiController.php
@@ -116,6 +116,12 @@ class ApiController extends BaseController
             file_put_contents($targetDir . '/errors.txt', print_r($context->errors, true));
             $this->stdout(count($context->errors) . " errors have been logged to $targetDir/errors.txt\n", Console::FG_RED, Console::BOLD);
         }
+
+        if (!empty($context->warnings)) {
+            ArrayHelper::multisort($context->warnings, 'file');
+            file_put_contents($targetDir . '/warnings.txt', print_r($context->warnings, true));
+            $this->stdout(count($context->warnings) . " warnings have been logged to $targetDir/warnings.txt\n", Console::FG_YELLOW, Console::BOLD);
+        }
     }
 
     /**

--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -105,7 +105,7 @@ class BaseDoc extends Object
         if ($docblock !== null) {
             $this->shortDescription = ucfirst($docblock->getShortDescription());
             if (empty($this->shortDescription) && !($this instanceof PropertyDoc) && $context !== null && $docblock->getTagsByName('inheritdoc') === null) {
-                $context->errors[] = [
+                $context->warnings[] = [
                     'line' => $this->startLine,
                     'file' => $this->sourceFile,
                     'message' => "No short description for " . substr(StringHelper::basename(get_class($this)), 0, -3) . " '{$this->name}'",
@@ -127,7 +127,7 @@ class BaseDoc extends Object
                 }
             }
         } elseif ($context !== null) {
-            $context->errors[] = [
+            $context->warnings[] = [
                 'line' => $this->startLine,
                 'file' => $this->sourceFile,
                 'message' => "No docblock for element '{$this->name}'",

--- a/models/Context.php
+++ b/models/Context.php
@@ -33,7 +33,14 @@ class Context extends Component
      * @var TraitDoc[]
      */
     public $traits = [];
+	/**
+	 * @var array
+	 */
     public $errors = [];
+	/**
+	 * @var array
+	 */
+    public $warnings = [];
 
 
     /**

--- a/models/Context.php
+++ b/models/Context.php
@@ -33,13 +33,14 @@ class Context extends Component
      * @var TraitDoc[]
      */
     public $traits = [];
-	/**
-	 * @var array
-	 */
+    /**
+     * @var array
+     */
     public $errors = [];
-	/**
-	 * @var array
-	 */
+    /**
+     * @var array
+     * @since 2.0.6
+     */
     public $warnings = [];
 
 

--- a/models/PropertyDoc.php
+++ b/models/PropertyDoc.php
@@ -83,7 +83,7 @@ class PropertyDoc extends BaseDoc
             }
         }
         if (empty($this->shortDescription) && $context !== null && !$hasInheritdoc) {
-            $context->errors[] = [
+            $context->warnings[] = [
                 'line' => $this->startLine,
                 'file' => $this->sourceFile,
                 'message' => "No short description for element '{$this->name}'",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Fixed issues  | -

Before:
![7b205099](https://cloud.githubusercontent.com/assets/5972388/20246676/51d19c38-a9bc-11e6-9f25-fcf671a10331.png)

After:
![6415d6c5](https://cloud.githubusercontent.com/assets/5972388/20246679/68ffd014-a9bc-11e6-8e09-b833f38d0df9.png)

Most of these warnings is about missing phpdoc in AssetsBundles. I think it is worth to separate such errors  (which will be just ignored on rendered page) from errors which will result broken links and probably means some typo.