### PR TITLE
www.php.net links with HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 2.1.3 under development
 -----------------------
 
-- Enh: www.php.net links with HTTPS (kamarton)
+- Enh #185: Use HTTPS for www.php.net links (kamarton)
 
 
 2.1.2 August 20, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 2.1.3 under development
 -----------------------
 
-- no changes in this release.
+- Enh: www.php.net links with HTTPS (kamarton)
 
 
 2.1.2 August 20, 2019

--- a/renderers/BaseRenderer.php
+++ b/renderers/BaseRenderer.php
@@ -129,7 +129,7 @@ abstract class BaseRenderer extends Component
                 // check if it is PHP internal class
                 if (((class_exists($type, false) || interface_exists($type, false) || trait_exists($type, false)) &&
                     ($reflection = new \ReflectionClass($type)) && $reflection->isInternal())) {
-                    $links[] = $this->generateLink($linkText, 'http://www.php.net/class.' . strtolower(ltrim($type, '\\')), $options) . $postfix;
+                    $links[] = $this->generateLink($linkText, 'https://www.php.net/class.' . strtolower(ltrim($type, '\\')), $options) . $postfix;
                 } elseif (in_array($type, $phpTypes)) {
                     if (isset($phpTypeDisplayAliases[$type])) {
                         $linkText = $phpTypeDisplayAliases[$type];
@@ -137,7 +137,7 @@ abstract class BaseRenderer extends Component
                     if (isset($phpTypeAliases[$type])) {
                         $type = $phpTypeAliases[$type];
                     }
-                    $links[] = $this->generateLink($linkText, 'http://www.php.net/language.types.' . strtolower(ltrim($type, '\\')), $options) . $postfix;
+                    $links[] = $this->generateLink($linkText, 'https://www.php.net/language.types.' . strtolower(ltrim($type, '\\')), $options) . $postfix;
                 } else {
                     $links[] = $type . $postfix;
                 }

--- a/tests/commands/ApiControllerTest.php
+++ b/tests/commands/ApiControllerTest.php
@@ -79,7 +79,7 @@ class ApiControllerTest extends TestCase
             <<<HTML
 <tr id="\$name">
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html#\$name-detail">\$name</a></td>
-    <td><a href="http://www.php.net/language.types.string">string</a></td>
+    <td><a href="https://www.php.net/language.types.string">string</a></td>
     <td>Animal name.</td>
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html">yiiunit\apidoc\data\api\animal\Animal</a></td>
 </tr>
@@ -90,7 +90,7 @@ HTML
             <<<HTML
 <tr id="\$birthDate">
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html#\$birthDate-detail">\$birthDate</a></td>
-    <td><a href="http://www.php.net/language.types.integer">integer</a></td>
+    <td><a href="https://www.php.net/language.types.integer">integer</a></td>
     <td>Animal birth date as a UNIX timestamp.</td>
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html">yiiunit\apidoc\data\api\animal\Animal</a></td>
 </tr>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

www.php.net permanently redirects to HTTPS.

```bash
$ curl -vvv http://www.php.net
* Rebuilt URL to: http://www.php.net/
*   Trying 2a02:cb40:200::1ad...
* TCP_NODELAY set
* Connected to www.php.net (2a02:cb40:200::1ad) port 80 (#0)
> GET / HTTP/1.1
> Host: www.php.net
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Server: myracloud
< Date: Fri, 03 Jan 2020 08:02:10 GMT
< Content-Type: text/html
< Content-Length: 177
< Connection: keep-alive
< Location: https://www.php.net/
< 
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>Myra</center>
</body>
</html>
```