### PR TITLE
Propagate @since to inherited methods/properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 apidoc extension Change Log
 
 - Enh #185: Use HTTPS for www.php.net links (kamarton)
 - Bug #187: Prevent getter/setter methods from affecting class-defined property docs (brandonkelly)
+- Enh #137: @since tags are now propagated to inherited methods/properties in the same package (brandonkelly)
 
 
 2.1.2 August 20, 2019

--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -86,6 +86,21 @@ class BaseDoc extends BaseObject
     }
 
     /**
+     * Returns the Composer package for this type, if it can be determined from [[sourceFile]].
+     *
+     * @return string|null
+     * @since 2.1.3
+     */
+    public function getPackageName()
+    {
+        if (!$this->sourceFile || !preg_match('/\/vendor\/([\w\-]+\/[\w\-]+)/', $this->sourceFile, $match)) {
+            return null;
+        }
+
+        return $match[1];
+    }
+
+    /**
      * @param \phpDocumentor\Reflection\BaseReflector $reflector
      * @param Context $context
      * @param array $config

--- a/models/Context.php
+++ b/models/Context.php
@@ -221,8 +221,12 @@ class Context extends Component
                 }
 
                 // set all properties that are empty.
-                foreach (['shortDescription', 'type', 'types'] as $property) {
+                foreach (['shortDescription', 'type', 'types', 'since'] as $property) {
                     if (empty($p->$property) || is_string($p->$property) && trim($p->$property) === '') {
+                        // only copy @since if the package names are equal (or missing)
+                        if ($property === 'since' && $p->getPackageName() !== $inheritedProperty->getPackageName()) {
+                            continue;
+                        }
                         $p->$property = $inheritedProperty->$property;
                     }
                 }
@@ -248,8 +252,12 @@ class Context extends Component
                     continue;
                 }
                 // set all properties that are empty.
-                foreach (['shortDescription', 'return', 'returnType', 'returnTypes', 'exceptions'] as $property) {
+                foreach (['shortDescription', 'return', 'returnType', 'returnTypes', 'exceptions', 'since'] as $property) {
                     if (empty($m->$property) || is_string($m->$property) && trim($m->$property) === '') {
+                        // only copy @since if the package names are equal (or missing)
+                        if ($property === 'since' && $m->getPackageName() !== $inheritedMethod->getPackageName()) {
+                            continue;
+                        }
                         $m->$property = $inheritedMethod->$property;
                     }
                 }


### PR DESCRIPTION
Also added `BaseDoc::getPackageName()` to help determine the package name of the method/property based on its sourceFile. If `getPackageName()` differs between the current method/property and its parent class it's inheriting from, then @since won't be copied.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #137
