### PR TITLE
Fixed invalid attempt to scan parent class of interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 2.1.7 under development
 -----------------------
 
-- no changes in this release.
+- Bug #210: Fixed invalid attempt to scan parent class of interface with `@inheritdoc` tag on a method (bizley)
 
 
 2.1.6 May 05, 2021

--- a/models/Context.php
+++ b/models/Context.php
@@ -306,7 +306,7 @@ class Context extends Component
         foreach($inheritanceCandidates as $candidate) {
             if (isset($candidate->methods[$method->name])) {
                 $cmethod = $candidate->methods[$method->name];
-                if ($cmethod->hasTag('inheritdoc')) {
+                if (!$candidate instanceof InterfaceDoc && $cmethod->hasTag('inheritdoc')) {
                     $this->inheritDocs($candidate);
                 }
                 $methods[] = $cmethod;


### PR DESCRIPTION
Fixed invalid attempt to scan parent class of interface with `@inheritdoc` tag on a method.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #210
