### PR TITLE
Improved highlighting of PHP templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 apidoc extension Change Log
 - Bug #210: Fixed invalid attempt to scan parent class of interface with `@inheritdoc` tag on a method (bizley)
 - Bug #218: Extended detection of `@inheritdoc` tag in `BaseDoc` (WinterSilence)
 - Bug #180: Fixed "All Classes" broken link (arogachev)
+- Bug #34: Improved highlighting of PHP templates (arogachev)
 
 
 2.1.6 May 05, 2021

--- a/helpers/MarkdownHighlightTrait.php
+++ b/helpers/MarkdownHighlightTrait.php
@@ -41,6 +41,10 @@ trait MarkdownHighlightTrait
         }
         try {
             if (isset($block['language'])) {
+                if ($block['language'] === 'php' && strpos($block['content'], '<?=')) {
+                    $block['language'] = 'html';
+                }
+
                 $result = self::$highlighter->highlight($block['language'], $block['content'] . "\n");
                 return "<pre><code class=\"hljs {$result->language} language-{$block['language']}\">{$result->value}</code></pre>\n";
             } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #34 

Seems like a solid workaround with minimal efforts / rewriting of code. Also it doesn't require manual replacing in the whole guide. Based on [this comment](https://github.com/scrivo/highlight.php/issues/74#issuecomment-624263627). Maybe there are more problematic cases, but from what I see it works fine.

Also here are visual diffs for blocks mentioned in the original issue.

Block 1, before:

![Screenshot 2021-11-29 at 11-47-45 Getting Data from Users Creating Forms](https://user-images.githubusercontent.com/8326201/143821267-7bf4770c-6aa6-4684-9357-54f7dddc17fa.png)

Block 1, after:

![Screenshot 2021-11-29 at 11-48-01 Getting Data from Users Creating Forms](https://user-images.githubusercontent.com/8326201/143821304-5262f4b1-8818-4de2-ad2f-df1161ca61b9.png)

Block 2, before:

![Screenshot 2021-11-29 at 12-43-19 Getting Started Working with Forms](https://user-images.githubusercontent.com/8326201/143821408-3f94288f-0040-468a-9a25-35c6e8dfc512.png)

Block 2, after:

![Screenshot 2021-11-29 at 12-44-26 Getting Started Working with Forms](https://user-images.githubusercontent.com/8326201/143821442-972b62d0-4fcd-4394-a757-f61d8b569555.png)
