### PR TITLE
BaseDoc::extractFirstSentence() must consider previous text

### DIFF
--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -221,21 +221,26 @@ class BaseDoc extends BaseObject
     /**
      * Extracts first sentence out of text
      * @param string $text
+     * @param string $prevText
      * @return string
      */
-    public static function extractFirstSentence($text)
+    public static function extractFirstSentence($text, $prevText = '')
     {
         if (mb_strlen($text, 'utf-8') > 4 && ($pos = mb_strpos($text, '.', 4, 'utf-8')) !== false) {
             $sentence = mb_substr($text, 0, $pos + 1, 'utf-8');
+            $prevText  = $prevText . $sentence;
+
             if (mb_strlen($text, 'utf-8') >= $pos + 3) {
                 $abbrev = mb_substr($text, $pos - 1, 4, 'utf-8');
                 // do not break sentence after abbreviation
                 if ($abbrev === 'e.g.' ||
                     $abbrev === 'i.e.' ||
-                    mb_substr_count($sentence, '`', 'utf-8') % 2 === 1 ||
-                    mb_substr_count($text, '`', 'utf-8') % 2 === 1
+                    mb_substr_count($prevText, '`', 'utf-8') % 2 === 1
                 ) {
-                    $sentence .= static::extractFirstSentence(mb_substr($text, $pos + 1, mb_strlen($text, 'utf-8'), 'utf-8'));
+                    $sentence .= static::extractFirstSentence(
+                        mb_substr($text, $pos + 1, mb_strlen($text, 'utf-8'), 'utf-8'),
+                        $prevText
+                    );
                 }
             }
             return $sentence;

--- a/tests/models/BaseDocTest.php
+++ b/tests/models/BaseDocTest.php
@@ -17,9 +17,15 @@ class BaseDocTest extends TestCase
      */
     public function testExtractFirstSentenceWithBackticks()
     {
-        $initialText = 'the host info (e.g. `http://www.example.com`) that is used by [[createAbsoluteUrl()]] to ' .
-            'prepend to created URLs.';
-        $firstSentence = BaseDoc::extractFirstSentence($initialText);
-        $this->assertEquals($initialText, $firstSentence);;
+        $initialText = 'fallback host info (e.g. `http://www.yiiframework.com`) used when ' .
+            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid. This value will replace ' .
+            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] before [[$denyCallback]] is called to make sure that ' .
+            'an invalid host will not be used for further processing. You can set it to `null` to leave ' .
+            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] untouched. Default value is empty string (this will ' .
+            'result creating relative URLs instead of absolute).';
+        $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
+        $expectedFirstSentence = 'fallback host info (e.g. `http://www.yiiframework.com`) used when ' .
+            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid.';
+        $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

A fix to the bug introduced in #228.
