### PR TITLE
Fixed a bug when a "virtual" / "magic" property's full description was displayed instead of preview in properties list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Yii Framework 2 apidoc extension Change Log
 - Enh #196: Added support for PHPDoc inline links (arogachev)
 - Enh #147: Added feature of viewing method source code without external links (arogachev)
 - Bug #168: Fixed handling of inheritance (arogachev)
+- Bug #240: Fixed a bug when a property's full description was displayed instead of preview in properties list 
+(arogachev)
 
 
 2.1.6 May 05, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Yii Framework 2 apidoc extension Change Log
 - Enh #196: Added support for PHPDoc inline links (arogachev)
 - Enh #147: Added feature of viewing method source code without external links (arogachev)
 - Bug #168: Fixed handling of inheritance (arogachev)
-- Bug #240: Fixed a bug when a property's full description was displayed instead of preview in properties list 
-(arogachev)
+- Bug #240: Fixed a bug when a "virtual" / "magic" property's full description was displayed instead of preview in 
+- properties list (arogachev)
 
 
 2.1.6 May 05, 2021

--- a/models/TypeDoc.php
+++ b/models/TypeDoc.php
@@ -201,6 +201,8 @@ class TypeDoc extends BaseDoc
             }
 
             if ($tag instanceof Property || $tag instanceof PropertyRead || $tag instanceof PropertyWrite) {
+                $shortDescription = $tag->getDescription() ? BaseDoc::extractFirstSentence($tag->getDescription()): '';
+
                 $property = new PropertyDoc(null, $context, [
                     'sourceFile' => $this->sourceFile,
                     'name' => '$' . $tag->getVariableName(),
@@ -209,7 +211,7 @@ class TypeDoc extends BaseDoc
                     'definedBy' => $this->name,
                     'type' => (string) $tag->getType(),
                     'types' => $this->splitTypes($tag->getType()),
-                    'shortDescription' => $tag->getDescription(),
+                    'shortDescription' => $shortDescription,
                     'description' => $tag->getDescription(),
                 ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #240
