### PR TITLE
Swap listings package with minted for better code highlighting in PDF guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Framework 2 apidoc extension Change Log
 - Bug #240: Fixed a bug when a "virtual" / "magic" property's full description was displayed instead of preview in 
   properties list (arogachev)
 - Bug #239: Do not show a "virtual" / "magic" methods's full description if it matches short description (arogachev)
+- Enh #134: Swapped listings package with minted for better code highlighting in PDF guide (arogachev)
 
 
 2.1.6 May 05, 2021

--- a/README.md
+++ b/README.md
@@ -211,7 +211,13 @@ cd $APIDOC_PATH
 
 ### Creating a PDF of the guide
 
-You need `pdflatex` and GNU `make` for this.
+Prerequisites:
+
+- `pdflatex`.
+- [Pygments](https://pygments.org/).
+- GNU `make`.
+
+Generation:
 
 ```
 vendor/bin/apidoc guide source/docs ./output --template=pdf

--- a/helpers/ApiMarkdownLaTeX.php
+++ b/helpers/ApiMarkdownLaTeX.php
@@ -72,6 +72,35 @@ class ApiMarkdownLaTeX extends GithubMarkdown
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function renderCode($block)
+    {
+        $language = $block['language'] ?? 'text';
+        // replace No-Break Space characters in code block, which do not render in LaTeX
+        $content = preg_replace("/[\x{00a0}\x{202f}]/u", ' ', $block['content']);
+        $options = $language === 'php' ? '[startinline=true]' : '';
+
+        return implode("\n", [
+            "\\begin{minted}$options{" . "$language}",
+            $content,
+            '\end{minted}',
+            '',
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function renderInlineCode($block)
+    {
+        // replace No-Break Space characters in code block, which do not render in LaTeX
+        $content = preg_replace("/[\x{00a0}\x{202f}]/u", ' ', $block[1]);
+
+        return '\\mintinline{text}{' . str_replace("\n", ' ', $content) . '}';
+    }
+
+    /**
      * Converts markdown into HTML
      *
      * @param string $content

--- a/helpers/ApiMarkdownLaTeX.php
+++ b/helpers/ApiMarkdownLaTeX.php
@@ -79,10 +79,9 @@ class ApiMarkdownLaTeX extends GithubMarkdown
         $language = $block['language'] ?? 'text';
         // replace No-Break Space characters in code block, which do not render in LaTeX
         $content = preg_replace("/[\x{00a0}\x{202f}]/u", ' ', $block['content']);
-        $options = $language === 'php' ? '[startinline=true]' : '';
 
         return implode("\n", [
-            "\\begin{minted}$options{" . "$language}",
+            "\\begin{minted}{" . "$language}",
             $content,
             '\end{minted}',
             '',

--- a/templates/pdf/GuideRenderer.php
+++ b/templates/pdf/GuideRenderer.php
@@ -23,18 +23,6 @@ class GuideRenderer extends \yii\apidoc\templates\html\GuideRenderer
      */
     public function render($files, $targetDir)
     {
-//        $types = array_merge($this->apiContext->classes, $this->apiContext->interfaces, $this->apiContext->traits);
-//
-//        $extTypes = [];
-//        foreach ($this->extensions as $k => $ext) {
-//            $extType = $this->filterTypes($types, $ext);
-//            if (empty($extType)) {
-//                unset($this->extensions[$k]);
-//                continue;
-//            }
-//            $extTypes[$ext] = $extType;
-//        }
-
         $fileCount = count($files) + 1;
         if ($this->controller !== null) {
             Console::startProgress(0, $fileCount, 'Rendering markdown files: ', false);
@@ -44,17 +32,11 @@ class GuideRenderer extends \yii\apidoc\templates\html\GuideRenderer
         $chapters = $this->loadGuideStructure($files);
         foreach ($files as $file) {
             $fileData[basename($file)] = file_get_contents($file);
-//            if (preg_match("/^(.*)\n=+/", $fileData[$file], $matches)) {
-//                $headlines[$file] = $matches[1];
-//            } else {
-//                $headlines[$file] = basename($file);
-//            }
         }
 
         $md = new ApiMarkdownLaTeX();
         $output = '';
         foreach ($chapters as $chapter) {
-
             if (isset($chapter['headline'])) {
                 $output .= '\chapter{' . $chapter['headline'] . "}\n";
             }

--- a/templates/pdf/Makefile
+++ b/templates/pdf/Makefile
@@ -2,8 +2,8 @@
 
 guide.pdf: guide-mod.tex main.tex title.tex
 	# run pdflatex twice to generate TOC correctly
-	pdflatex -halt-on-error main.tex
-	pdflatex -halt-on-error main.tex
+	pdflatex -halt-on-error -shell-escape main.tex
+	pdflatex -halt-on-error -shell-escape main.tex
 	mv main.pdf guide.pdf
 
 guide-mod.tex: guide.tex main.tex

--- a/templates/pdf/main.tex
+++ b/templates/pdf/main.tex
@@ -80,6 +80,12 @@ urlcolor=linkcol %couleur des liens pour les url
 
 % code highlighting
 \usepackage{minted}
+\setminted{
+    breaklines,
+    breaksymbolleft=,
+    fontsize=\scriptsize,
+}
+\setminted[php]{startinline=true}
 
 \definecolor{codebg}{rgb}{0.9,0.9,0.9}
 \definecolor{mygreen}{rgb}{0,0.6,0}

--- a/templates/pdf/main.tex
+++ b/templates/pdf/main.tex
@@ -78,8 +78,8 @@ urlcolor=linkcol %couleur des liens pour les url
 \title{\plainTitle}
 \author{\plainAuthors}
 
-% code listings
-\usepackage{listings}
+% code highlighting
+\usepackage{minted}
 
 \definecolor{codebg}{rgb}{0.9,0.9,0.9}
 \definecolor{mygreen}{rgb}{0,0.6,0}
@@ -88,89 +88,6 @@ urlcolor=linkcol %couleur des liens pour les url
 
 % TODO ensure copyable indentation:
 % http://tex.stackexchange.com/questions/142617/copy-pasting-leading-whitespace-and-blank-lines-in-listings-package-pdf
-
-\lstset{%
-  backgroundcolor=\color{codebg},   % choose the background color; you must add \usepackage{color} or \usepackage{xcolor}
-  basicstyle=\ttfamily\footnotesize, % the size of the fonts that are used for the code
-  columns=fullflexible,
-  breakatwhitespace=false,         % sets if automatic breaks should only happen at whitespace
-  breaklines=true,                 % sets automatic line breaking
-  extendedchars=true,              % lets you use non-ASCII characters; for 8-bits encodings only, does not work with UTF-8
-  keepspaces=true,                 % keeps spaces in text, useful for keeping indentation of code (possibly needs columns=flexible)
-%
-  commentstyle=\color{mygreen},    % comment style
-  keywordstyle=\color{blue},       % keyword style
-  stringstyle=\color{mymauve},     % string literal style
-%
-% language=Octave,                 % the language of the code
-% morekeywords={*,...},            % if you want to add more keywords to the set
-% deletekeywords={...},            % if you want to delete keywords from the given language
-%
-  numbers=none,                    % where to put the line-numbers; possible values are (none, left, right), not using line numbers to allow copy&paste
-  stepnumber=1,                    % the step between two line-numbers. If it's 1, each line will be numbered
-  numbersep=5pt,                   % how far the line-numbers are from the code
-  numberstyle=\tiny\color{mygray}, % the style that is used for the line-numbers
-%
-  showspaces=false,                % show spaces everywhere adding particular underscores; it overrides 'showstringspaces'
-  showstringspaces=false,          % underline spaces within strings only
-  showtabs=false,                  % show tabs within strings adding particular underscores
-%
-  tabsize=2,                       % sets default tabsize to 2 spaces
-%  title=\lstname                   % show the filename of files included with \lstinputlisting; also try caption instead of title
-%
-    literate={-}{-}1,
-    %    {\'}{'}1,
-    %    {\"}{\"}1
-  extendedchars=false
-}
-
-\lstdefinelanguage{json}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
-
-\lstdefinelanguage{css}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
-
-\lstdefinelanguage{less}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
-
-\lstdefinelanguage{scss}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
-
-\lstdefinelanguage{javascript}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
-
-\lstdefinelanguage{apache}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
-
-\lstdefinelanguage{nginx}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
-
-\lstdefinelanguage{bash}{
-	morekeywords={},
-	sensitive=false,
-	morestring=[b]",
-}
 
 % include images
 \usepackage{graphicx}

--- a/templates/pdf/main.tex
+++ b/templates/pdf/main.tex
@@ -83,7 +83,7 @@ urlcolor=linkcol %couleur des liens pour les url
 \setminted{
     breaklines,
     breaksymbolleft=,
-    fontsize=\scriptsize,
+    fontsize=\footnotesize,
 }
 \setminted[php]{startinline=true}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #134, #170

Some brief visual examples of changes.

Before (PHP):

![Screenshot from 2021-12-09 17-46-59](https://user-images.githubusercontent.com/8326201/145391148-14d4c7bd-1b30-4f21-a92b-2be4338df070.png)

After (PHP):

![Screenshot from 2021-12-09 18-30-30](https://user-images.githubusercontent.com/8326201/145396851-10bb59c8-c222-42fb-bd9d-258b6c14cfdc.png)

Before (JS):

![Screenshot from 2021-12-10 13-20-11](https://user-images.githubusercontent.com/8326201/145533722-986269e0-8205-45fd-8dab-b5aa07b42709.png)

After (JS):

![Screenshot from 2021-12-10 13-17-53](https://user-images.githubusercontent.com/8326201/145533747-eb1b89e7-b121-4cec-ab64-43685525e2ba.png)

