### PR TITLE
Render API link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Yii Framework 2 apidoc extension Change Log
   properties list (arogachev)
 - Bug #239: Do not show a "virtual" / "magic" methods's full description if it matches short description (arogachev)
 - Enh #134: Swapped listings package with minted for better code highlighting in PDF guide (arogachev)
-- Enh #161: Render API link text (arogachev)
+- Enh #161: Render API link text in web guide (arogachev)
 
 
 2.1.6 May 05, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Yii Framework 2 apidoc extension Change Log
   properties list (arogachev)
 - Bug #239: Do not show a "virtual" / "magic" methods's full description if it matches short description (arogachev)
 - Enh #134: Swapped listings package with minted for better code highlighting in PDF guide (arogachev)
+- Enh #161: Render API link text (arogachev)
 
 
 2.1.6 May 05, 2021

--- a/helpers/ApiMarkdownLaTeX.php
+++ b/helpers/ApiMarkdownLaTeX.php
@@ -36,7 +36,14 @@ class ApiMarkdownLaTeX extends GithubMarkdown
     protected function renderApiLink($block)
     {
         // TODO allow break also on camel case
-        $latex = '\texttt{'.str_replace(['\\textbackslash', '::'], ['\allowbreak{}\\textbackslash', '\allowbreak{}::\allowbreak{}'], $this->escapeLatex(strip_tags($block[1]))).'}';
+        $latex = '\texttt{';
+        $latex .= str_replace(
+            ['\\textbackslash', '::'],
+            ['\allowbreak{}\\textbackslash', '\allowbreak{}::\allowbreak{}'],
+            $this->escapeLatex(strip_tags($block[1]))
+        );
+        $latex .= '}';
+
         return $latex;
     }
 

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -7,10 +7,12 @@
 
 namespace yii\apidoc\helpers;
 
+use DOMDocument;
 use yii\apidoc\models\ClassDoc;
 use yii\apidoc\models\InterfaceDoc;
 use yii\apidoc\models\MethodDoc;
 use yii\apidoc\models\TypeDoc;
+use yii\helpers\Markdown;
 
 /**
  * Class ApiMarkdownTrait
@@ -31,6 +33,7 @@ trait ApiMarkdownTrait
         $offset = strlen($matches[0]);
         $object = $matches[1];
         $title = (empty($matches[2]) || $matches[2] === '|') ? null : substr($matches[2], 1);
+        $title = $this->renderApiLinkText($title);
 
         /** @var TypeDoc[] $contexts */
         $contexts = [];
@@ -188,6 +191,23 @@ trait ApiMarkdownTrait
     protected function renderBrokenApiLink($block)
     {
         return $block[1];
+    }
+
+    /**
+     * @param null|string $title
+     * @return null|string
+     */
+    protected function renderApiLinkText($title)
+    {
+        if (!$title) {
+            return $title;
+        }
+
+        $title = Markdown::process($title);
+        $doc = new DOMDocument();
+        $doc->loadHTML($title);
+
+        return $doc->getElementsByTagName('p')[0]->childNodes[0]->c14n();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #161

Now it's possible to write:

<pre>[[ApplicationTrait::getEntries()|`Craft::$app->entries`]]</pre>
<pre>[[ApplicationTrait::getEntries()|*Craft::$app->entries*]]</pre>
<pre>[[ApplicationTrait::getEntries()|**Craft::$app->entries**]]`</pre>

etc.

PDF version is left as is (all HTML tags are stripped). Not sure if we need to change this behavior. Can be discussed.
