### PR TITLE
Use repo url only in api, fixed regression of processing absolute links containing word "guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,6 @@ OPTIONS
 
 --page-title: string
 
---repo-url: string
-  Repository url (e.g. "https://github.com/yiisoft/yii2"). Optional, used for resolving relative links
-  within a repository (e.g. "[docs/guide/README.md](docs/guide/README.md)"). If you don't have such links you can
-  skip this. Otherwise, skipping this will cause generation of broken links because they will be not resolved and
-  left as is.
-
 --silent-exit-on-exception: boolean, 0 or 1
   if true - script finish with `ExitCode::OK` in case of exception.
   false - `ExitCode::UNSPECIFIED_ERROR`.

--- a/commands/ApiController.php
+++ b/commands/ApiController.php
@@ -30,6 +30,13 @@ class ApiController extends BaseController
      * @var string prefix to prepend to all guide file names.
      */
     public $guidePrefix = 'guide-';
+    /**
+     * @var string Repository url (e.g. "https://github.com/yiisoft/yii2"). Optional, used for resolving relative links
+     * within a repository (e.g. "[docs/guide/README.md](docs/guide/README.md)"). If you don't have such links you can
+     * skip this. Otherwise, skipping this will cause generation of broken links because they will be not resolved and
+     * left as is.
+     */
+    public $repoUrl;
 
 
     // TODO add force update option
@@ -186,6 +193,6 @@ class ApiController extends BaseController
      */
     public function options($actionID)
     {
-        return array_merge(parent::options($actionID), ['guide', 'guidePrefix']);
+        return array_merge(parent::options($actionID), ['guide', 'guidePrefix', 'repoUrl']);
     }
 }

--- a/components/BaseController.php
+++ b/components/BaseController.php
@@ -33,13 +33,6 @@ abstract class BaseController extends Controller
      * @var string
      */
     public $pageTitle;
-    /**
-     * @var string Repository url (e.g. "https://github.com/yiisoft/yii2"). Optional, used for resolving relative links
-     * within a repository (e.g. "[docs/guide/README.md](docs/guide/README.md)"). If you don't have such links you can
-     * skip this. Otherwise, skipping this will cause generation of broken links because they will be not resolved and
-     * left as is.
-     */
-    public $repoUrl;
 
 
     /**
@@ -167,6 +160,6 @@ abstract class BaseController extends Controller
      */
     public function options($actionID)
     {
-        return array_merge(parent::options($actionID), ['template', 'exclude', 'pageTitle', 'repoUrl']);
+        return array_merge(parent::options($actionID), ['template', 'exclude', 'pageTitle']);
     }
 }

--- a/helpers/ApiMarkdown.php
+++ b/helpers/ApiMarkdown.php
@@ -136,11 +136,6 @@ class ApiMarkdown extends GithubMarkdown
             return parent::renderLink($block);
         }
 
-        //skip parsing external url
-        if ((strpos($url, 'https://') !== false) || (strpos($url, 'http://') !== false) ) {
-            return parent::renderLink($block);
-        }
-
         $linkHtml = parent::renderLink($block);
         // add special syntax for linking to the guide
         $guideLinkHtml = preg_replace_callback('/href="guide:([A-z0-9-.#]+)"/i', function ($matches) {
@@ -148,6 +143,10 @@ class ApiMarkdown extends GithubMarkdown
         }, $linkHtml, 1);
         if ($guideLinkHtml !== $linkHtml) {
             return $guideLinkHtml;
+        }
+
+        if (!property_exists(static::$renderer, 'repoUrl')) {
+            return $linkHtml;
         }
 
         $repoUrl = static::$renderer->repoUrl;

--- a/renderers/ApiRenderer.php
+++ b/renderers/ApiRenderer.php
@@ -8,6 +8,7 @@
 namespace yii\apidoc\renderers;
 
 use Yii;
+use yii\apidoc\commands\ApiController;
 use yii\apidoc\models\Context;
 
 /**
@@ -18,6 +19,12 @@ use yii\apidoc\models\Context;
  */
 abstract class ApiRenderer extends BaseRenderer
 {
+    /**
+     * @var string
+     * @see ApiController::$repoUrl
+     */
+    public $repoUrl;
+
     /**
      * Renders a given [[Context]].
      *

--- a/renderers/BaseRenderer.php
+++ b/renderers/BaseRenderer.php
@@ -51,10 +51,6 @@ abstract class BaseRenderer extends Component
      */
     public $controller;
     public $guideUrl;
-    /**
-     * @var string
-     */
-    public $repoUrl;
 
 
     public function init()
@@ -239,6 +235,11 @@ abstract class BaseRenderer extends Component
      */
     public function generateGuideUrl($file)
     {
+        //skip parsing external url
+        if ((strpos($file, 'https://') !== false) || (strpos($file, 'http://') !== false) ) {
+            return $file;
+        }
+
         $hash = '';
         if (($pos = strpos($file, '#')) !== false) {
             $hash = substr($file, $pos);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Fixes after retest of #256 (logic + regression)
