### PR TITLE
Resolve static return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Yii Framework 2 apidoc extension Change Log
 - Bug #241: Do not show a method's source code when it's empty (arogachev)
 - Enh #159: Added support to relative links within a repository in HTML API (arogachev)
 - Enh #36: Allow to customize "All classes url" and "Available since version" label for type in HTML API (arogachev)
+- Enh #126: Resolve static return type (arogachev)
 
 
 2.1.6 May 05, 2021

--- a/models/Context.php
+++ b/models/Context.php
@@ -445,6 +445,7 @@ class Context extends Component
                     // Override the setter-defined property if it exists already
                     $class->properties[$propertyName] = new PropertyDoc(null, $this, [
                         'name' => $propertyName,
+                        'fullName' => "$class->name::$propertyName",
                         'definedBy' => $method->definedBy,
                         'sourceFile' => $class->sourceFile,
                         'visibility' => 'public',
@@ -478,6 +479,7 @@ class Context extends Component
                     $param = $this->getFirstNotOptionalParameter($method);
                     $class->properties[$propertyName] = new PropertyDoc(null, $this, [
                         'name' => $propertyName,
+                        'fullName' => "$class->name::$propertyName",
                         'definedBy' => $method->definedBy,
                         'sourceFile' => $class->sourceFile,
                         'visibility' => 'public',

--- a/models/TypeDoc.php
+++ b/models/TypeDoc.php
@@ -202,10 +202,12 @@ class TypeDoc extends BaseDoc
 
             if ($tag instanceof Property || $tag instanceof PropertyRead || $tag instanceof PropertyWrite) {
                 $shortDescription = $tag->getDescription() ? BaseDoc::extractFirstSentence($tag->getDescription()): '';
+                $name = '$' . $tag->getVariableName();
 
                 $property = new PropertyDoc(null, $context, [
                     'sourceFile' => $this->sourceFile,
-                    'name' => '$' . $tag->getVariableName(),
+                    'name' => $name,
+                    'fullName' => ltrim((string) $reflector->getFqsen(), '\\') . '::' . $name,
                     'isStatic' => false,
                     'visibility' => 'public',
                     'definedBy' => $this->name,
@@ -239,6 +241,7 @@ class TypeDoc extends BaseDoc
                 $method = new MethodDoc(null, $context, [
                     'sourceFile' => $this->sourceFile,
                     'name' => $tag->getMethodName(),
+                    'fullName' => ltrim((string) $reflector->getFqsen(), '\\') . '::' . $tag->getMethodName(),
                     'shortDescription' => $shortDescription,
                     'description' => $description,
                     'visibility' => 'public',

--- a/renderers/BaseRenderer.php
+++ b/renderers/BaseRenderer.php
@@ -176,14 +176,11 @@ abstract class BaseRenderer extends Component
     {
         $returnTypes = [];
         foreach ($method->returnTypes as $returnType) {
-            if ($returnType !== 'static' && $returnType !== 'static[]') {
+            if ($returnType === 'static' || $returnType === 'static[]') {
+                $returnTypes[] = str_replace('static', $method->definedBy, $returnType);
+            } else {
                 $returnTypes[] = $returnType;
-
-                continue;
             }
-
-
-            $returnTypes[] = str_replace('static', $method->definedBy, $returnType);
         }
 
         return $this->createTypeLink($returnTypes, $type);

--- a/renderers/BaseRenderer.php
+++ b/renderers/BaseRenderer.php
@@ -52,6 +52,41 @@ abstract class BaseRenderer extends Component
     public $controller;
     public $guideUrl;
 
+    /**
+     * @var string[]
+     */
+    private $phpTypes = [
+        'callable',
+        'array',
+        'string',
+        'boolean',
+        'bool',
+        'integer',
+        'int',
+        'float',
+        'object',
+        'resource',
+        'null',
+        'false',
+        'true',
+    ];
+    /**
+     * @var string[]
+     */
+    private $phpTypeAliases = [
+        'true' => 'boolean',
+        'false' => 'boolean',
+        'bool' => 'boolean',
+        'int' => 'integer',
+    ];
+    /**
+     * @var string[]
+     */
+    private $phpTypeDisplayAliases = [
+        'bool' => 'boolean',
+        'int' => 'integer',
+    ];
+
 
     public function init()
     {
@@ -62,8 +97,8 @@ abstract class BaseRenderer extends Component
     /**
      * creates a link to a type (class, interface or trait)
      * @param ClassDoc|InterfaceDoc|TraitDoc|ClassDoc[]|InterfaceDoc[]|TraitDoc[]|string|string[] $types
+     * @param BaseDoc|null $context
      * @param string $title a title to be used for the link TODO check whether [[yii\...|Class]] is supported
-     * @param BaseDoc $context
      * @param array $options additional HTML attributes for the link.
      * @return string
      */
@@ -91,8 +126,6 @@ abstract class BaseRenderer extends Component
                     $type = $t;
                 } elseif (!empty($type) && $type[0] !== '\\' && ($t = $this->apiContext->getType($this->resolveNamespace($context) . '\\' . ltrim($type, '\\'))) !== null) {
                     $type = $t;
-                } else {
-                    ltrim($type, '\\');
                 }
             }
 
@@ -106,41 +139,16 @@ abstract class BaseRenderer extends Component
                     $linkText = $title;
                     $title = null;
                 }
-                $phpTypes = [
-                    'callable',
-                    'array',
-                    'string',
-                    'boolean',
-                    'bool',
-                    'integer',
-                    'int',
-                    'float',
-                    'object',
-                    'resource',
-                    'null',
-                    'false',
-                    'true',
-                ];
-                $phpTypeAliases = [
-                    'true' => 'boolean',
-                    'false' => 'boolean',
-                    'bool' => 'boolean',
-                    'int' => 'integer',
-                ];
-                $phpTypeDisplayAliases = [
-                    'bool' => 'boolean',
-                    'int' => 'integer',
-                ];
                 // check if it is PHP internal class
                 if (((class_exists($type, false) || interface_exists($type, false) || trait_exists($type, false)) &&
                     ($reflection = new \ReflectionClass($type)) && $reflection->isInternal())) {
                     $links[] = $this->generateLink($linkText, 'https://www.php.net/class.' . strtolower(ltrim($type, '\\')), $options) . $postfix;
-                } elseif (in_array($type, $phpTypes)) {
-                    if (isset($phpTypeDisplayAliases[$type])) {
-                        $linkText = $phpTypeDisplayAliases[$type];
+                } elseif (in_array($type, $this->phpTypes)) {
+                    if (isset($this->phpTypeDisplayAliases[$type])) {
+                        $linkText = $this->phpTypeDisplayAliases[$type];
                     }
-                    if (isset($phpTypeAliases[$type])) {
-                        $type = $phpTypeAliases[$type];
+                    if (isset($this->phpTypeAliases[$type])) {
+                        $type = $this->phpTypeAliases[$type];
                     }
                     $links[] = $this->generateLink($linkText, 'https://www.php.net/language.types.' . strtolower(ltrim($type, '\\')), $options) . $postfix;
                 } else {
@@ -157,6 +165,28 @@ abstract class BaseRenderer extends Component
         }
 
         return implode('|', $links);
+    }
+
+    /**
+     * @param MethodDoc $method
+     * @param TypeDoc $type
+     * @return string
+     */
+    public function createMethodReturnTypeLink($method, $type)
+    {
+        $returnTypes = [];
+        foreach ($method->returnTypes as $returnType) {
+            if ($returnType !== 'static' && $returnType !== 'static[]') {
+                $returnTypes[] = $returnType;
+
+                continue;
+            }
+
+
+            $returnTypes[] = str_replace('static', $method->definedBy, $returnType);
+        }
+
+        return $this->createTypeLink($returnTypes, $type);
     }
 
     /**

--- a/templates/bootstrap/layouts/api.php
+++ b/templates/bootstrap/layouts/api.php
@@ -37,45 +37,27 @@ $this->beginContent('@yii/apidoc/templates/bootstrap/layouts/main.php', isset($t
                 'active' => isset($type) && ($class->name == $type->name),
             ];
         } ?>
-        <?= SideNavWidget::widget([
-            'id' => 'navigation',
-            'items' => $nav,
-            'view' => $this,
-        ])?>
+        <?= SideNavWidget::widget(['id' => 'navigation', 'items' => $nav, 'view' => $this])?>
     </div>
-    <div class="col-md-9 api-content" role="main">
-        <?= $content ?>
-    </div>
+    <div class="col-md-9 api-content" role="main"><?= $content ?></div>
 </div>
 
 <script type="text/javascript">
     /*<![CDATA[*/
-    $("a.toggle").on('click', function () {
+    $('a.toggle').on('click', function () {
         var $this = $(this);
         if ($this.hasClass('properties-hidden')) {
             $this.text($this.text().replace(/Show/,'Hide'));
-            $this.parents(".summary").find(".inherited").show();
+            $this.parents('.toggle-target-container').find('.inherited').show();
             $this.removeClass('properties-hidden');
         } else {
             $this.text($this.text().replace(/Hide/,'Show'));
-            $this.parents(".summary").find(".inherited").hide();
+            $this.parents('.toggle-target-container').find('.inherited').hide();
             $this.addClass('properties-hidden');
         }
 
         return false;
     });
-    /*
-     $(".sourceCode a.show").toggle(function () {
-     $(this).text($(this).text().replace(/show/,'hide'));
-     $(this).parents(".sourceCode").find("div.code").show();
-     },function () {
-     $(this).text($(this).text().replace(/hide/,'show'));
-     $(this).parents(".sourceCode").find("div.code").hide();
-     });
-     $("a.sourceLink").click(function () {
-     $(this).attr('target','_blank');
-     });
-     */
     /*]]>*/
 </script>
 

--- a/templates/html/views/constSummary.php
+++ b/templates/html/views/constSummary.php
@@ -4,47 +4,66 @@ use yii\apidoc\helpers\ApiMarkdown;
 use yii\apidoc\models\ClassDoc;
 use yii\helpers\ArrayHelper;
 
-/* @var $type ClassDoc */
 /* @var $this yii\web\View */
-/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
+/* @var $type ClassDoc */
 
+/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 $renderer = $this->context;
 
 if (empty($type->constants)) {
     return;
 }
+
 $constants = $type->constants;
 ArrayHelper::multisort($constants, 'name');
 ?>
-<div class="summary doc-const">
+
+<div class="doc-const summary toggle-target-container">
     <h2>Constants</h2>
 
     <p><a href="#" class="toggle">Hide inherited constants</a></p>
 
     <table class="summary-table table table-striped table-bordered table-hover">
-    <colgroup>
-        <col class="col-const" />
-        <col class="col-value" />
-        <col class="col-description" />
-        <col class="col-defined" />
-    </colgroup>
-    <tr>
-        <th>Constant</th><th>Value</th><th>Description</th><th>Defined By</th>
-    </tr>
-    <?php foreach ($constants as $constant): ?>
-        <tr<?= $constant->definedBy != $type->name ? ' class="inherited"' : '' ?> id="<?= $constant->name ?>">
-          <td id="<?= $constant->name ?>-detail"><?= $constant->name ?></td>
-          <td><?= $constant->value ?></td>
-          <td><?= ApiMarkdown::process($constant->shortDescription . "\n" . $constant->description, $constant->definedBy, true) ?>
-              <?php if (!empty($constant->deprecatedSince) || !empty($constant->deprecatedReason)): ?>
-                  <strong>Deprecated <?php
-                      if (!empty($constant->deprecatedSince))  { echo 'since version ' . $constant->deprecatedSince . ': '; }
-                      if (!empty($constant->deprecatedReason)) { echo ApiMarkdown::process($constant->deprecatedReason, $constant->definedBy, true); }
-                      ?></strong>
-              <?php endif; ?>
-          </td>
-          <td><?= $renderer->createTypeLink($constant->definedBy) ?></td>
+        <colgroup>
+            <col class="col-const" />
+            <col class="col-value" />
+            <col class="col-description" />
+            <col class="col-defined" />
+        </colgroup>
+        <tr>
+            <th>Constant</th>
+            <th>Value</th>
+            <th>Description</th>
+            <th>Defined By</th>
         </tr>
-    <?php endforeach; ?>
+
+        <?php foreach ($constants as $constant) { ?>
+            <tr id="<?= $constant->name ?>" class="<?= $constant->definedBy != $type->name ? 'inherited' : '' ?>">
+              <td id="<?= $constant->name ?>-detail"><?= $constant->name ?></td>
+              <td><?= $constant->value ?></td>
+              <td>
+                  <?= ApiMarkdown::process($constant->shortDescription . "\n" . $constant->description,
+                      $constant->definedBy,
+                      true
+                  ) ?>
+                  <?php if (!empty($constant->deprecatedSince) || !empty($constant->deprecatedReason)) { ?>
+                      <strong>
+                          Deprecated
+
+                          <?php
+                          if (!empty($constant->deprecatedSince)) {
+                              echo 'since version ' . $constant->deprecatedSince . ': ';
+                          }
+
+                          if (!empty($constant->deprecatedReason)) {
+                              echo ApiMarkdown::process($constant->deprecatedReason, $constant->definedBy, true);
+                          }
+                          ?>
+                      </strong>
+                  <?php } ?>
+              </td>
+              <td><?= $renderer->createTypeLink($constant->definedBy) ?></td>
+            </tr>
+        <?php } ?>
     </table>
 </div>

--- a/templates/html/views/eventDetails.php
+++ b/templates/html/views/eventDetails.php
@@ -4,60 +4,84 @@ use yii\apidoc\helpers\ApiMarkdown;
 use yii\apidoc\models\ClassDoc;
 use yii\helpers\ArrayHelper;
 
-/* @var $type ClassDoc */
 /* @var $this yii\web\View */
-/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
+/* @var $type ClassDoc */
 
+/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 $renderer = $this->context;
 
 $events = $type->getNativeEvents();
 if (empty($events)) {
     return;
 }
+
 ArrayHelper::multisort($events, 'name');
 ?>
+
 <h2>Event Details</h2>
 
-<div class="event-doc">
-<?php foreach ($events as $event): ?>
-    <div class="detail-header h3" id="<?= $event->name.'-detail' ?>">
-        <a href="#" class="tool-link" title="go to top"><span class="glyphicon glyphicon-arrow-up"></span></a>
-        <?= $renderer->createSubjectLink($event, '<span class="glyphicon icon-hash"></span>', [
-            'title' => 'direct link to this method',
-            'class' => 'tool-link hash',
-        ]) ?>
+<div class="event-doc toggle-target-container">
+    <p><a href="#" class="toggle">Hide inherited properties</a></p>
 
-        <?php if (($sourceUrl = $renderer->getSourceUrl($event->definedBy, $event->startLine)) !== null): ?>
-            <a href="<?= str_replace('/blob/', '/edit/', $sourceUrl) ?>" class="tool-link" title="edit on github"><span class="glyphicon glyphicon-pencil"></span></a>
-            <a href="<?= $sourceUrl ?>" class="tool-link" title="view source on github"><span class="glyphicon glyphicon-eye-open"></span></a>
-        <?php endif; ?>
+    <?php foreach ($events as $event) { ?>
+        <div id="<?= $event->name . '-detail' ?>">
+            <div class="detail-header h3">
+                <a href="#" class="tool-link" title="go to top"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                <?= $renderer->createSubjectLink($event, '<span class="glyphicon icon-hash"></span>', [
+                    'title' => 'direct link to this method',
+                    'class' => 'tool-link hash',
+                ]) ?>
 
-        <?= $event->name ?>
-        <span class="detail-header-tag small">
-        event
-        of type <?= $renderer->createTypeLink($event->types) ?>
-        <?php if (!empty($event->since)): ?>
-            (available since version <?= $event->since ?>)
-        <?php endif; ?>
-        </span>
-    </div>
+                <?php if (($sourceUrl = $renderer->getSourceUrl($event->definedBy, $event->startLine)) !== null) { ?>
+                    <a href="<?= str_replace('/blob/', '/edit/', $sourceUrl) ?>" class="tool-link"
+                       title="edit on github">
+                        <span class="glyphicon glyphicon-pencil"></span>
+                    </a>
+                    <a href="<?= $sourceUrl ?>" class="tool-link" title="view source on github">
+                        <span class="glyphicon glyphicon-eye-open"></span>
+                    </a>
+                <?php } ?>
 
-    <?php if (!empty($event->deprecatedSince) || !empty($event->deprecatedReason)): ?>
-        <div class="doc-description deprecated">
-            <strong>Deprecated <?php
-                if (!empty($event->deprecatedSince))  { echo 'since version ' . $event->deprecatedSince . ': '; }
-                if (!empty($event->deprecatedReason)) { echo ApiMarkdown::process($event->deprecatedReason, $event->definedBy, true); }
-                ?></strong>
+                <?= $event->name ?>
+
+                <span class="detail-header-tag small">
+                    event of type
+                    <?= $renderer->createTypeLink($event->types) ?>
+                    <?= !empty($event->since) ? "(available since version $event->since)" : '' ?>
+                </span>
+            </div>
+
+            <?php if (!empty($event->deprecatedSince) || !empty($event->deprecatedReason)) { ?>
+                <div class="doc-description deprecated">
+                    <strong>
+                        Deprecated
+
+                        <?php
+                        if (!empty($event->deprecatedSince)) {
+                            echo 'since version ' . $event->deprecatedSince . ': ';
+                        }
+
+                        if (!empty($event->deprecatedReason)) {
+                            echo ApiMarkdown::process($event->deprecatedReason, $event->definedBy, true);
+                        }
+                        ?>
+                    </strong>
+                </div>
+            <?php } ?>
+
+            <div class="doc-description">
+                <?php if ($type->name !== $event->definedBy) { ?>
+                    <p>
+                        <strong>Defined in:</strong>
+                        <?= $renderer->createSubjectLink($event, $event->fullName) ?>
+                    </p>
+                <?php } ?>
+
+                <?= ApiMarkdown::process($event->description, $type) ?>
+                <?= $this->render('seeAlso', ['object' => $event]) ?>
+            </div>
+
+            <?= $this->render('@yii/apidoc/templates/html/views/changelog', ['doc' => $event]) ?>
         </div>
-    <?php endif; ?>
-
-    <div class="doc-description">
-        <?= ApiMarkdown::process($event->description, $type) ?>
-
-        <?= $this->render('seeAlso', ['object' => $event]) ?>
-    </div>
-
-    <?= $this->render('@yii/apidoc/templates/html/views/changelog', ['doc' => $event]) ?>
-
-<?php endforeach; ?>
+    <?php } ?>
 </div>

--- a/templates/html/views/eventSummary.php
+++ b/templates/html/views/eventSummary.php
@@ -4,45 +4,51 @@ use yii\apidoc\helpers\ApiMarkdown;
 use yii\apidoc\models\ClassDoc;
 use yii\helpers\ArrayHelper;
 
-/* @var $type ClassDoc */
 /* @var $this yii\web\View */
-/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
+/* @var $type ClassDoc */
 
+/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 $renderer = $this->context;
 
 if (empty($type->events)) {
     return;
 }
+
 $events = $type->events;
 ArrayHelper::multisort($events, 'name');
 ?>
-<div class="summary doc-event">
+
+<div class="doc-event summary toggle-target-container">
     <h2>Events</h2>
 
     <p><a href="#" class="toggle">Hide inherited events</a></p>
 
     <table class="summary-table table table-striped table-bordered table-hover">
-    <colgroup>
-        <col class="col-event" />
-        <col class="col-type" />
-        <col class="col-description" />
-        <col class="col-defined" />
-    </colgroup>
-    <tr>
-        <th>Event</th><th>Type</th><th>Description</th><th>Defined By</th>
-    </tr>
-    <?php foreach ($events as $event): ?>
-    <tr<?= $event->definedBy != $type->name ? ' class="inherited"' : '' ?> id="<?= $event->name ?>">
-        <td><?= $renderer->createSubjectLink($event) ?></td>
-        <td><?= $renderer->createTypeLink($event->types) ?></td>
-        <td>
-            <?= ApiMarkdown::process($event->shortDescription, $event->definedBy, true) ?>
-            <?php if (!empty($event->since)): ?>
-                (available since version <?= $event->since ?>)
-            <?php endif; ?>
-        </td>
-        <td><?= $renderer->createTypeLink($event->definedBy) ?></td>
-    </tr>
-    <?php endforeach; ?>
+        <colgroup>
+            <col class="col-event" />
+            <col class="col-type" />
+            <col class="col-description" />
+            <col class="col-defined" />
+        </colgroup>
+        <tr>
+            <th>Event</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Defined By</th>
+        </tr>
+
+        <?php foreach ($events as $event) { ?>
+            <tr id="<?= $event->name ?>" class="<?= $event->definedBy !== $type->name ? 'inherited' : '' ?>">
+                <td><?= $renderer->createSubjectLink($event, null, [], $type) ?></td>
+                <td><?= $renderer->createTypeLink($event->types) ?></td>
+                <td>
+                    <?= ApiMarkdown::process($event->shortDescription, $event->definedBy, true) ?>
+                    <?php if (!empty($event->since)) { ?>
+                        (available since version <?= $event->since ?>)
+                    <?php } ?>
+                </td>
+                <td><?= $renderer->createTypeLink($event->definedBy) ?></td>
+            </tr>
+        <?php } ?>
     </table>
 </div>

--- a/templates/html/views/methodDetails.php
+++ b/templates/html/views/methodDetails.php
@@ -77,7 +77,7 @@ ArrayHelper::multisort($methods, 'name');
             <?php if (!empty($method->return)): ?>
                 <tr>
                   <th class="param-name-col">return</th>
-                  <td class="param-type-col"><?= $renderer->createTypeLink($method->returnTypes, $type) ?></td>
+                  <td class="param-type-col"><?= $renderer->createMethodReturnTypeLink($method, $type) ?></td>
                   <td class="param-desc-col"><?= ApiMarkdown::process($method->return, $method->definedBy) ?></td>
                 </tr>
             <?php endif; ?>

--- a/templates/html/views/methodDetails.php
+++ b/templates/html/views/methodDetails.php
@@ -5,98 +5,127 @@ use yii\apidoc\models\ClassDoc;
 use yii\apidoc\models\TraitDoc;
 use yii\helpers\ArrayHelper;
 
-/* @var $type ClassDoc|TraitDoc */
 /* @var $this yii\web\View */
-/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
+/* @var $type ClassDoc|TraitDoc */
 /* @var $highlighter \Highlight\Highlighter */
 
+/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 $renderer = $this->context;
 
-$methods = $type->getNativeMethods();
+$methods = $type->methods;
 if (empty($methods)) {
     return;
 }
+
 ArrayHelper::multisort($methods, 'name');
 ?>
+
 <h2>Method Details</h2>
 
-<div class="method-doc">
-<?php foreach ($methods as $method): ?>
+<div class="method-doc toggle-target-container">
+    <p><a href="#" class="toggle">Hide inherited methods</a></p>
 
-    <div class="detail-header h3" id="<?= $method->name . '()-detail' ?>">
-        <a href="#" class="tool-link" title="go to top"><span class="glyphicon glyphicon-arrow-up"></span></a>
-        <?= $renderer->createSubjectLink($method, '<span class="glyphicon icon-hash"></span>', [
-            'title' => 'direct link to this method',
-            'class' => 'tool-link hash',
-        ]) ?>
+    <?php foreach ($methods as $method) { ?>
+        <div id="<?= $method->name . '()-detail' ?>"
+             class="<?= $method->definedBy !== $type->name ? 'inherited': '' ?>">
+            <div class="detail-header h3">
+                <a href="#" class="tool-link" title="go to top"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                <?= $renderer->createSubjectLink($method, '<span class="glyphicon icon-hash"></span>', [
+                    'title' => 'direct link to this method',
+                    'class' => 'tool-link hash',
+                ], $type) ?>
 
-        <?php if (($sourceUrl = $renderer->getSourceUrl($method->definedBy, $method->startLine)) !== null): ?>
-            <a href="<?= str_replace('/blob/', '/edit/', $sourceUrl) ?>" class="tool-link" title="edit on github"><span class="glyphicon glyphicon-pencil"></span></a>
-            <a href="<?= $sourceUrl ?>" class="tool-link" title="view source on github"><span class="glyphicon glyphicon-eye-open"></span></a>
-        <?php endif; ?>
+                <?php if (($sourceUrl = $renderer->getSourceUrl($method->definedBy, $method->startLine)) !== null) { ?>
+                    <a href="<?= str_replace('/blob/', '/edit/', $sourceUrl) ?>" class="tool-link"
+                       title="edit on github">
+                        <span class="glyphicon glyphicon-pencil"></span>
+                    </a>
+                    <a href="<?= $sourceUrl ?>" class="tool-link" title="view source on github">
+                        <span class="glyphicon glyphicon-eye-open"></span>
+                    </a>
+                <?php } ?>
 
-        <?= $method->name ?>()
-        <span class="detail-header-tag small">
-            <?= $method->visibility ?>
-            <?= $method->isAbstract ? 'abstract' : '' ?>
-            <?= $method->isStatic ? 'static' : '' ?>
-            method
-            <?php if (!empty($method->since)): ?>
-                (available since version <?= $method->since ?>)
-            <?php endif; ?>
-        </span>
-    </div>
+                <?= $method->name ?>()
 
-    <?php if (!empty($method->deprecatedSince) || !empty($method->deprecatedReason)): ?>
-        <div class="doc-description deprecated">
-            <strong>Deprecated <?php
-                if (!empty($method->deprecatedSince))  { echo 'since version ' . $method->deprecatedSince . ': '; }
-                if (!empty($method->deprecatedReason)) { echo ApiMarkdown::process($method->deprecatedReason, $method->definedBy, true); }
-                ?></strong>
+                <span class="detail-header-tag small">
+                    <?= $method->visibility ?>
+                    <?= $method->isAbstract ? 'abstract' : '' ?>
+                    <?= $method->isStatic ? 'static' : '' ?>
+                    method
+                    <?= !empty($method->since) ? "(available since version $method->since)" : '' ?>
+                </span>
+            </div>
+
+            <?php if (!empty($method->deprecatedSince) || !empty($method->deprecatedReason)) { ?>
+                <div class="doc-description deprecated">
+                    <strong>
+                        Deprecated
+
+                        <?php if (!empty($method->deprecatedSince))  {
+                            echo 'since version ' . $method->deprecatedSince . ': ';
+                        }
+
+                        if (!empty($method->deprecatedReason)) {
+                            echo ApiMarkdown::process($method->deprecatedReason, $method->definedBy, true);
+                        } ?>
+                    </strong>
+                </div>
+            <?php } ?>
+
+            <div class="doc-description">
+                <?php if ($type->name !== $method->definedBy) { ?>
+                    <p>
+                        <strong>Defined in:</strong>
+                        <?= $renderer->createSubjectLink($method, $method->fullName . '()') ?>
+                    </p>
+                <?php } ?>
+
+                <p><strong><?= ApiMarkdown::process($method->shortDescription, $method->definedBy, true) ?></strong></p>
+                <?= ApiMarkdown::process($method->description, $method->definedBy) ?>
+                <?= $this->render('seeAlso', ['object' => $method]) ?>
+            </div>
+
+            <table class="detail-table table table-striped table-bordered table-hover">
+                <tr><td colspan="3" class="signature"><?= $renderer->renderMethodSignature($method, $type) ?></td></tr>
+
+                <?php if (!empty($method->params) || !empty($method->return) || !empty($method->exceptions)) { ?>
+                    <?php foreach ($method->params as $param) { ?>
+                        <tr>
+                            <td class="param-name-col"><?= ApiMarkdown::highlight($param->name, 'php') ?></td>
+                            <td class="param-type-col"><?= $renderer->createTypeLink($param->types) ?></td>
+                            <td class="param-desc-col">
+                               <?= ApiMarkdown::process($param->description, $method->definedBy) ?>
+                            </td>
+                        </tr>
+                    <?php } ?>
+
+                    <?php if (!empty($method->return)) { ?>
+                        <tr>
+                            <th class="param-name-col">return</th>
+                            <td class="param-type-col"><?= $renderer->createMethodReturnTypeLink($method, $type) ?></td>
+                            <td class="param-desc-col">
+                                <?= ApiMarkdown::process($method->return, $method->definedBy) ?>
+                            </td>
+                        </tr>
+                    <?php } ?>
+
+                    <?php foreach ($method->exceptions as $exception => $description) { ?>
+                        <tr>
+                            <th class="param-name-col">throws</th>
+                            <td class="param-type-col"><?= $renderer->createTypeLink($exception) ?></td>
+                            <td class="param-desc-col">
+                                <?= ApiMarkdown::process($description, $method->definedBy) ?>
+                            </td>
+                        </tr>
+                    <?php } ?>
+                <?php } ?>
+            </table>
+
+            <?= $this->render('@yii/apidoc/templates/html/views/changelog', ['doc' => $method]) ?>
+            <?= $this->render('@yii/apidoc/templates/html/views/methodSourceCode',
+                ['method' => $method, 'highlighter' => $highlighter]
+            ) ?>
+            <?= $this->render('@yii/apidoc/templates/html/views/todos', ['doc' => $method]) ?>
         </div>
-    <?php endif; ?>
-
-    <div class="doc-description">
-        <p><strong><?= ApiMarkdown::process($method->shortDescription, $method->definedBy, true) ?></strong></p>
-
-        <?= ApiMarkdown::process($method->description, $method->definedBy) ?>
-
-        <?= $this->render('seeAlso', ['object' => $method]) ?>
-    </div>
-
-    <table class="detail-table table table-striped table-bordered table-hover">
-        <tr><td colspan="3" class="signature"><?= $renderer->renderMethodSignature($method, $type) ?></td></tr>
-        <?php if (!empty($method->params) || !empty($method->return) || !empty($method->exceptions)): ?>
-            <?php foreach ($method->params as $param): ?>
-                <tr>
-                  <td class="param-name-col"><?= ApiMarkdown::highlight($param->name, 'php') ?></td>
-                  <td class="param-type-col"><?= $renderer->createTypeLink($param->types) ?></td>
-                  <td class="param-desc-col"><?= ApiMarkdown::process($param->description, $method->definedBy) ?></td>
-                </tr>
-            <?php endforeach; ?>
-            <?php if (!empty($method->return)): ?>
-                <tr>
-                  <th class="param-name-col">return</th>
-                  <td class="param-type-col"><?= $renderer->createMethodReturnTypeLink($method, $type) ?></td>
-                  <td class="param-desc-col"><?= ApiMarkdown::process($method->return, $method->definedBy) ?></td>
-                </tr>
-            <?php endif; ?>
-            <?php foreach ($method->exceptions as $exception => $description): ?>
-                <tr>
-                  <th class="param-name-col">throws</th>
-                  <td class="param-type-col"><?= $renderer->createTypeLink($exception) ?></td>
-                  <td class="param-desc-col"><?= ApiMarkdown::process($description, $method->definedBy) ?></td>
-                </tr>
-            <?php endforeach; ?>
-        <?php endif; ?>
-    </table>
-
-    <?= $this->render('@yii/apidoc/templates/html/views/changelog', ['doc' => $method]) ?>
-    <?= $this->render(
-        '@yii/apidoc/templates/html/views/methodSourceCode',
-        ['method' => $method, 'highlighter' => $highlighter]
-    ) ?>
-    <?= $this->render('@yii/apidoc/templates/html/views/todos', ['doc' => $method]) ?>
-
-<?php endforeach; ?>
+    <?php } ?>
 </div>

--- a/templates/html/views/methodSummary.php
+++ b/templates/html/views/methodSummary.php
@@ -6,42 +6,54 @@ use yii\apidoc\models\InterfaceDoc;
 use yii\apidoc\models\TraitDoc;
 use yii\helpers\ArrayHelper;
 
+/* @var $this yii\web\View */
 /* @var $type ClassDoc|InterfaceDoc|TraitDoc */
 /* @var $protected bool */
-/* @var $this yii\web\View */
-/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 
+
+/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 $renderer = $this->context;
 
-if ($protected && count($type->getProtectedMethods()) == 0 || !$protected && count($type->getPublicMethods()) == 0) {
+if (
+    ($protected && count($type->getProtectedMethods()) === 0) ||
+    (!$protected && count($type->getPublicMethods()) === 0)
+) {
     return;
-} ?>
+}
+?>
 
-<div class="summary doc-method">
-<h2><?= $protected ? 'Protected Methods' : 'Public Methods' ?></h2>
+<div class="doc-method summary toggle-target-container">
+    <h2><?= $protected ? 'Protected Methods' : 'Public Methods' ?></h2>
 
-<p><a href="#" class="toggle">Hide inherited methods</a></p>
+    <p><a href="#" class="toggle">Hide inherited methods</a></p>
 
-<table class="summary-table table table-striped table-bordered table-hover">
-<colgroup>
-    <col class="col-method" />
-    <col class="col-description" />
-    <col class="col-defined" />
-</colgroup>
-<tr>
-  <th>Method</th><th>Description</th><th>Defined By</th>
-</tr>
-<?php
-$methods = $type->methods;
-ArrayHelper::multisort($methods, 'name');
-foreach ($methods as $method): ?>
-    <?php if ($protected && $method->visibility == 'protected' || !$protected && $method->visibility != 'protected'): ?>
-    <tr<?= $method->definedBy != $type->name ? ' class="inherited"' : '' ?> id="<?= $method->name ?>()">
-        <td><?= $renderer->createSubjectLink($method, $method->name . '()') ?></td>
-        <td><?= ApiMarkdown::process($method->shortDescription, $method->definedBy, true) ?></td>
-        <td><?= $renderer->createTypeLink($method->definedBy, $type) ?></td>
-    </tr>
-    <?php endif; ?>
-<?php endforeach; ?>
-</table>
+    <table class="summary-table table table-striped table-bordered table-hover">
+        <colgroup>
+            <col class="col-method" />
+            <col class="col-description" />
+            <col class="col-defined" />
+        </colgroup>
+        <tr>
+            <th>Method</th>
+            <th>Description</th>
+            <th>Defined By</th>
+        </tr>
+
+        <?php
+        $methods = $type->methods;
+        ArrayHelper::multisort($methods, 'name');
+
+        foreach ($methods as $method) { ?>
+            <?php if (
+                ($protected && $method->visibility == 'protected') ||
+                (!$protected && $method->visibility != 'protected')
+            ) { ?>
+                <tr id="<?= $method->name ?>()" class="<?= $method->definedBy !== $type->name ? 'inherited' : '' ?>">
+                    <td><?= $renderer->createSubjectLink($method, $method->name . '()', [], $type) ?></td>
+                    <td><?= ApiMarkdown::process($method->shortDescription, $method->definedBy, true) ?></td>
+                    <td><?= $renderer->createTypeLink($method->definedBy, $type) ?></td>
+                </tr>
+            <?php } ?>
+        <?php } ?>
+    </table>
 </div>

--- a/templates/html/views/propertyDetails.php
+++ b/templates/html/views/propertyDetails.php
@@ -5,67 +5,91 @@ use yii\apidoc\models\ClassDoc;
 use yii\apidoc\models\TraitDoc;
 use yii\helpers\ArrayHelper;
 
-/* @var $type ClassDoc|TraitDoc */
 /* @var $this yii\web\View */
-/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
+/* @var $type ClassDoc|TraitDoc */
 
+/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 $renderer = $this->context;
 
 $properties = $type->getNativeProperties();
 if (empty($properties)) {
     return;
 }
+
 ArrayHelper::multisort($properties, 'name');
 ?>
+
 <h2>Property Details</h2>
 
-<div class="property-doc">
-<?php foreach ($properties as $property): ?>
+<div class="property-doc toggle-target-container">
+    <p><a href="#" class="toggle">Hide inherited properties</a></p>
 
-    <div class="detail-header h3" id="<?= $property->name.'-detail' ?>">
-        <a href="#" class="tool-link" title="go to top"><span class="glyphicon glyphicon-arrow-up"></span></a>
-        <?= $renderer->createSubjectLink($property, '<span class="glyphicon icon-hash"></span>', [
-            'title' => 'direct link to this method',
-            'class' => 'tool-link hash',
-        ]) ?>
+    <?php foreach ($properties as $property) { ?>
+        <div id="<?= $property->name . '-detail' ?>">
+            <div class="detail-header h3">
+                <a href="#" class="tool-link" title="go to top"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                <?= $renderer->createSubjectLink($property, '<span class="glyphicon icon-hash"></span>', [
+                    'title' => 'direct link to this method',
+                    'class' => 'tool-link hash',
+                ]) ?>
 
-        <?php if (($sourceUrl = $renderer->getSourceUrl($property->definedBy, $property->startLine)) !== null): ?>
-            <a href="<?= str_replace('/blob/', '/edit/', $sourceUrl) ?>" class="tool-link" title="edit on github"><span class="glyphicon glyphicon-pencil"></span></a>
-            <a href="<?= $sourceUrl ?>" class="tool-link" title="view source on github"><span class="glyphicon glyphicon-eye-open"></span></a>
-        <?php endif; ?>
+                <?php if (
+                    ($sourceUrl = $renderer->getSourceUrl($property->definedBy, $property->startLine)) !== null
+                ) { ?>
+                    <a href="<?= str_replace('/blob/', '/edit/', $sourceUrl) ?>" class="tool-link"
+                       title="edit on github">
+                        <span class="glyphicon glyphicon-pencil"></span>
+                    </a>
+                    <a href="<?= $sourceUrl ?>" class="tool-link" title="view source on github">
+                        <span class="glyphicon glyphicon-eye-open"></span>
+                    </a>
+                <?php } ?>
 
-        <?= $property->name ?>
-        <span class="detail-header-tag small">
-            <?= $property->visibility ?>
-            <?= $property->isStatic ? 'static' : '' ?>
-            <?php if ($property->getIsReadOnly()) echo ' <em>read-only</em> '; ?>
-            <?php if ($property->getIsWriteOnly()) echo ' <em>write-only</em> '; ?>
-            property
-            <?php if (!empty($property->since)): ?>
-                (available since version <?= $property->since ?>)
-            <?php endif; ?>
-        </span>
-    </div>
+                <?= $property->name ?>
 
-    <?php if (!empty($property->deprecatedSince) || !empty($property->deprecatedReason)): ?>
-        <div class="doc-description deprecated">
-            <strong>Deprecated <?php
-                if (!empty($property->deprecatedSince))  { echo 'since version ' . $property->deprecatedSince . ': '; }
-                if (!empty($property->deprecatedReason)) { echo ApiMarkdown::process($property->deprecatedReason, $property->definedBy, true); }
-                ?></strong>
+                <span class="detail-header-tag small">
+                    <?= $property->visibility ?>
+                    <?= $property->isStatic ? 'static' : '' ?>
+                    <?= $property->getIsReadOnly() ? '<em>read-only</em> ' : '' ?>
+                    <?= $property->getIsWriteOnly() ? '<em>write-only</em> ' : ''?>
+                    property
+                    <?= !empty($property->since) ? "(available since version $property->since)" : '' ?>
+                </span>
+            </div>
+
+            <?php if (!empty($property->deprecatedSince) || !empty($property->deprecatedReason)) { ?>
+                <div class="doc-description deprecated">
+                    <strong>
+                        Deprecated
+
+                        <?php
+                        if (!empty($property->deprecatedSince))  {
+                            echo 'since version ' . $property->deprecatedSince . ': ';
+                        }
+
+                        if (!empty($property->deprecatedReason)) {
+                            echo ApiMarkdown::process($property->deprecatedReason, $property->definedBy, true);
+                        }
+                        ?>
+                    </strong>
+                </div>
+            <?php } ?>
+
+            <div class="doc-description">
+                <?php if ($type->name !== $property->definedBy) { ?>
+                    <p>
+                        <strong>Defined in:</strong>
+                        <?= $renderer->createSubjectLink($property, $property->fullName) ?>
+                    </p>
+                <?php } ?>
+
+                <?= ApiMarkdown::process($property->description, $property->definedBy) ?>
+                <?= $this->render('seeAlso', ['object' => $property]) ?>
+            </div>
+
+            <div class="signature"><?= $renderer->renderPropertySignature($property, $type); ?></div>
+            <?= $this->render('@yii/apidoc/templates/html/views/changelog', ['doc' => $property]) ?>
+            <?= $this->render('@yii/apidoc/templates/html/views/todos', ['doc' => $property]) ?>
         </div>
-    <?php endif; ?>
-
-    <div class="doc-description">
-        <?= ApiMarkdown::process($property->description, $property->definedBy) ?>
-
-        <?= $this->render('seeAlso', ['object' => $property]) ?>
-    </div>
-
-    <div class="signature"><?php echo $renderer->renderPropertySignature($property, $type); ?></div>
-
-    <?= $this->render('@yii/apidoc/templates/html/views/changelog', ['doc' => $property]) ?>
-    <?= $this->render('@yii/apidoc/templates/html/views/todos', ['doc' => $property]) ?>
-
-<?php endforeach; ?>
+    <?php } ?>
 </div>

--- a/templates/html/views/propertySummary.php
+++ b/templates/html/views/propertySummary.php
@@ -5,44 +5,55 @@ use yii\apidoc\models\ClassDoc;
 use yii\apidoc\models\TraitDoc;
 use yii\helpers\ArrayHelper;
 
+/* @var $this yii\web\View */
 /* @var $type ClassDoc|TraitDoc */
 /* @var $protected bool */
-/* @var $this yii\web\View */
-/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 
+/* @var $renderer \yii\apidoc\templates\html\ApiRenderer */
 $renderer = $this->context;
 
-if ($protected && count($type->getProtectedProperties()) == 0 || !$protected && count($type->getPublicProperties()) == 0) {
+if (
+    ($protected && count($type->getProtectedProperties()) === 0) ||
+    (!$protected && count($type->getPublicProperties()) === 0)) {
     return;
-} ?>
+}
+?>
 
-<div class="summary doc-property">
-<h2><?= $protected ? 'Protected Properties' : 'Public Properties' ?></h2>
+<div class="doc-property summary toggle-target-container">
+    <h2><?= $protected ? 'Protected Properties' : 'Public Properties' ?></h2>
 
-<p><a href="#" class="toggle">Hide inherited properties</a></p>
+    <p><a href="#" class="toggle">Hide inherited properties</a></p>
 
-<table class="summary-table table table-striped table-bordered table-hover">
-<colgroup>
-    <col class="col-property" />
-    <col class="col-type" />
-    <col class="col-description" />
-    <col class="col-defined" />
-</colgroup>
-<tr>
-  <th>Property</th><th>Type</th><th>Description</th><th>Defined By</th>
-</tr>
-<?php
-$properties = $type->properties;
-ArrayHelper::multisort($properties, 'name');
-foreach ($properties as $property): ?>
-    <?php if ($protected && $property->visibility == 'protected' || !$protected && $property->visibility != 'protected'): ?>
-    <tr<?= $property->definedBy != $type->name ? ' class="inherited"' : '' ?> id="<?= $property->name ?>">
-        <td><?= $renderer->createSubjectLink($property) ?></td>
-        <td><?= $renderer->createTypeLink($property->types) ?></td>
-        <td><?= ApiMarkdown::process($property->shortDescription, $property->definedBy, true) ?></td>
-        <td><?= $renderer->createTypeLink($property->definedBy) ?></td>
-    </tr>
-    <?php endif; ?>
-<?php endforeach; ?>
-</table>
+    <table class="summary-table table table-striped table-bordered table-hover">
+        <colgroup>
+            <col class="col-property" />
+            <col class="col-type" />
+            <col class="col-description" />
+            <col class="col-defined" />
+        </colgroup>
+        <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Defined By</th>
+        </tr>
+
+        <?php
+        $properties = $type->properties;
+        ArrayHelper::multisort($properties, 'name');
+
+        foreach ($properties as $property) { ?>
+            <?php if (
+                ($protected && $property->visibility === 'protected') ||
+                (!$protected && $property->visibility !== 'protected')
+            ) { ?>
+                <tr id="<?= $property->name ?>" class="<?= $property->definedBy !== $type->name ? 'inherited' : '' ?>">
+                    <td><?= $renderer->createSubjectLink($property, null, [], $type) ?></td>
+                    <td><?= $renderer->createTypeLink($property->types) ?></td>
+                    <td><?= ApiMarkdown::process($property->shortDescription, $property->definedBy, true) ?></td>
+                    <td><?= $renderer->createTypeLink($property->definedBy) ?></td>
+                </tr>
+            <?php }; ?>
+        <?php } ?>
+    </table>
 </div>

--- a/tests/commands/ApiControllerTest.php
+++ b/tests/commands/ApiControllerTest.php
@@ -77,7 +77,7 @@ class ApiControllerTest extends TestCase
         $this->assertStringContainsString('Animal is a base class for animals.', $animalContent);
         $this->assertContainsWithoutIndent(
             <<<HTML
-<tr id="\$name">
+<tr id="\$name" class="">
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html#\$name-detail">\$name</a></td>
     <td><a href="https://www.php.net/language.types.string">string</a></td>
     <td>Animal name.</td>
@@ -88,7 +88,7 @@ HTML
         );
         $this->assertContainsWithoutIndent(
             <<<HTML
-<tr id="\$birthDate">
+<tr id="\$birthDate" class="">
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html#\$birthDate-detail">\$birthDate</a></td>
     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
     <td>Animal birth date as a UNIX timestamp.</td>
@@ -99,7 +99,7 @@ HTML
         );
         $this->assertContainsWithoutIndent(
             <<<HTML
-<tr id="getAge()">
+<tr id="getAge()" class="">
 <td><a href="yiiunit-apidoc-data-api-animal-animal.html#getAge()-detail">getAge()</a></td>
 <td>Returns animal age in seconds.</td>
 <td><a href="yiiunit-apidoc-data-api-animal-animal.html">yiiunit\apidoc\data\api\animal\Animal</a></td>
@@ -109,7 +109,7 @@ HTML
         );
         $this->assertContainsWithoutIndent(
             <<<HTML
-<tr id="render()">
+<tr id="render()" class="">
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html#render()-detail">render()</a></td>
     <td>Renders animal description.</td>
     <td><a href="yiiunit-apidoc-data-api-animal-animal.html">yiiunit\apidoc\data\api\animal\Animal</a></td>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #124

Still have doubts if it's worth it but related changes could be useful in the future. Anyways, here are things done:

- Inherited and magic methods' details are now included to a current page:
  - All summary links lead to the same page now.
  - For inherited methods the link for external page moved to details.
  - Adapted toggle for using with details and added it for hiding inherited methods.
  - The same applies to properties and events (for consistency).
  - Other features like viewing method's source code without leaving current page are supported.
- Added missing full name for magic properties and methods (defined via PHPDoc tags `@property` / `@method` and getters / setters).
 - Minor refactoring. Diffs are better be viewed in IDE since there are many indentation changes.

Visual demo (methods' amount is omitted for brevity):

![Peek 2021-12-28 11-21](https://user-images.githubusercontent.com/8326201/147531009-a18a1a4b-bd17-43d0-a560-ce6511b32ecd.gif)