### PR TITLE
Freeze "phpdocumentor/reflection" fork on specific commit while it's used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.2 || ^8.0",
         "yiisoft/yii2": "~2.0.16",
         "yiisoft/yii2-bootstrap": "~2.0.0",
-        "phpdocumentor/reflection": "dev-access-phpparser-node",
+        "phpdocumentor/reflection": "dev-access-phpparser-node#248d5525216f19216e642c8e09d5faa02d7382c6",
         "nikic/php-parser": "^4.0",
         "cebe/js-search": "~0.9.0",
         "cebe/markdown": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Related issue - #263. There were recent changes, so this freeze is required while fork is used.