### PR TITLE
Remove inline code in headlines in PDF guide

### DIFF
--- a/helpers/ApiMarkdownLaTeX.php
+++ b/helpers/ApiMarkdownLaTeX.php
@@ -72,7 +72,11 @@ class ApiMarkdownLaTeX extends GithubMarkdown
 
     protected function renderHeadline($block)
     {
-        $block['content'] = str_replace('`', '', $block['content']);
+        foreach ($block['content'] as $i => &$item) {
+            if ($item[0] === 'inlinecode') {
+                unset($block['content'][$i]);
+            }
+        }
 
         return parent::renderHeadline($block);
     }

--- a/helpers/ApiMarkdownLaTeX.php
+++ b/helpers/ApiMarkdownLaTeX.php
@@ -70,6 +70,13 @@ class ApiMarkdownLaTeX extends GithubMarkdown
         return "$translation ";
     }
 
+    protected function renderHeadline($block)
+    {
+        $block['content'] = str_replace('`', '', $block['content']);
+
+        return parent::renderHeadline($block);
+    }
+
     /**
      * Renders a blockquote
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |  

Not rendered anyway, but causes minted to crash during guide generation (if followed by another inline code block, Japanese language is affected).
