### PR TITLE
Fix error: Call to a member function getNamespaceAliases() on null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 Yii Framework 2 apidoc extension Change Log
 ===========================================
 
-3.0.1 under development
+3.0.2 under development
 -----------------------
 
 - no changes in this release.
+
+
+3.0.1 under development
+-----------------------
+
+- Bug #278: Fix error: Call to a member function `getNamespaceAliases()` on null (arogachev)
 
 
 3.0.0 January 14, 2022

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -111,6 +111,10 @@ trait ApiMarkdownTrait
             $subjectName = substr($object, $pos + 2);
 
             if ($context !== null) {
+                if (!$context->phpDocContext) {
+                    throw new BrokenLinkException($object, $context);
+                }
+
                 if (isset($context->phpDocContext->getNamespaceAliases()[$typeName])) {
                     $typeName = $context->phpDocContext->getNamespaceAliases()[$typeName];
                 } else {
@@ -147,6 +151,10 @@ trait ApiMarkdownTrait
                     ['apiLink', static::$renderer->createSubjectLink($subject, $title)],
                     $offset
                 ];
+            }
+
+            if (!$context->phpDocContext) {
+                throw new BrokenLinkException($object, $context);
             }
 
             if (isset($context->phpDocContext->getNamespaceAliases()[$object])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #278 
