### PR TITLE
Do not cache Context::getReflectionProject() at instance level because it can cause apidoc cache to contain not actual data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 Yii Framework 2 apidoc extension Change Log
 ===========================================
 
+3.0.3 under development
+-----------------------
+- no changes in this release.
+
+
 3.0.2 under development
 -----------------------
 
-- no changes in this release.
+- Bug #280 : Do not cache `Context::getReflectionProject()` at instance level because it can cause apidoc cache to 
+  contain not actual data. (arogachev).
 
 
 3.0.1 February 08, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,10 @@
 Yii Framework 2 apidoc extension Change Log
 ===========================================
 
-3.0.3 under development
------------------------
-- no changes in this release.
-
-
 3.0.2 under development
 -----------------------
 
-- Bug #280 : Do not cache `Context::getReflectionProject()` at instance level because it can cause apidoc cache to 
-  contain not actual data. (arogachev).
+- Bug #280: Do not cache `Context::getReflectionProject()` at instance level because it can cause apidoc cache to contain stale data (arogachev)
 
 
 3.0.1 February 08, 2022

--- a/models/Context.php
+++ b/models/Context.php
@@ -46,11 +46,6 @@ class Context extends Component
      */
     public $warnings = [];
 
-    /**
-     * @var Project
-     */
-    private $reflectionProject;
-
 
     /**
      * Returning TypeDoc for a type given
@@ -556,10 +551,6 @@ class Context extends Component
 
     public function getReflectionProject()
     {
-        if ($this->reflectionProject !== null) {
-            return $this->reflectionProject;
-        }
-
         $files = [];
         foreach ($this->files as $fileName => $hash) {
             $files[] = new LocalFile($fileName);
@@ -572,8 +563,6 @@ class Context extends Component
         $projectFactory->addStrategy(new ClassConstantFactory($docBlockFactory, new PrettyPrinter()), $priority);
         $projectFactory->addStrategy(new PropertyFactory($docBlockFactory, new PrettyPrinter()), $priority);
 
-        $this->reflectionProject = $projectFactory->create('ApiDoc', $files);
-
-        return $this->reflectionProject;
+        return $projectFactory->create('ApiDoc', $files);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft-contrib/yiiframework.com/issues/986
