### PR TITLE
Convert newlines to spaces and consider the first sentence ended only if the dot is followed by a space in `BaseDoc::extractFirstSentence()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ Yii Framework 2 apidoc extension Change Log
 
 3.0.4 under development
 -----------------------
-
-- Bug #282: Fix `BaseDoc::extractFirstSentence()` (WinterSilence)
+определение конца первого предложения в тексте
+- Bug #282: Fix determining end of first sentence in `BaseDoc::extractFirstSentence()` (WinterSilence)
 
 
 3.0.3 February 19, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 3.0.4 under development
 -----------------------
 
-- Bug #282: Fix determining end of first sentence in `BaseDoc::extractFirstSentence()` (WinterSilence)
+- Bug #282: Consider the first sentence ended only if the dot is followed by a space in `BaseDoc::extractFirstSentence()` (WinterSilence)
 
 
 3.0.3 February 19, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 apidoc extension Change Log
 
 3.0.4 under development
 -----------------------
-определение конца первого предложения в тексте
+
 - Bug #282: Fix determining end of first sentence in `BaseDoc::extractFirstSentence()` (WinterSilence)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 3.0.4 under development
 -----------------------
 
-- no changes in this release.
+- Bug #282: Fix `BaseDoc::extractFirstSentence()` (WinterSilence)
 
 
 3.0.3 February 19, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 3.0.4 under development
 -----------------------
 
-- Bug #282: Consider the first sentence ended only if the dot is followed by a space in `BaseDoc::extractFirstSentence()` (WinterSilence)
+- Bug #282: Convert newlines to spaces and consider the first sentence ended only if the dot is followed by a space in `BaseDoc::extractFirstSentence()` (WinterSilence)
 
 
 3.0.3 February 19, 2022

--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -246,7 +246,7 @@ class BaseDoc extends BaseObject
             $prevText  = $prevText . $sentence;
 
             if ($length >= $pos + 4) {
-                $abbrev = mb_substr($text, $pos - 2, 4, 'utf-8');
+                $abbrev = mb_substr($text, $pos - 3, 4, 'utf-8');
                 // do not break sentence after abbreviation
                 if ($abbrev === 'e.g.' ||
                     $abbrev === 'i.e.' ||

--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -242,10 +242,10 @@ class BaseDoc extends BaseObject
         $text = str_replace(["\r\n", "\n"], ' ', $text);
         $length = mb_strlen($text, 'utf-8');
         if ($length > 4 && ($pos = mb_strpos($text, '. ', 4, 'utf-8')) !== false) {
-            $sentence = mb_substr($text, 0, $pos + 2, 'utf-8');
+            $sentence = mb_substr($text, 0, $pos + 1, 'utf-8');
             $prevText  = $prevText . $sentence;
 
-            if ($length >= $pos + 4) {
+            if ($length >= $pos + 3) {
                 $abbrev = mb_substr($text, $pos - 3, 4, 'utf-8');
                 // do not break sentence after abbreviation
                 if ($abbrev === 'e.g.' ||
@@ -253,7 +253,7 @@ class BaseDoc extends BaseObject
                     mb_substr_count($prevText, '`', 'utf-8') % 2 === 1
                 ) {
                     $sentence .= static::extractFirstSentence(
-                        mb_substr($text, $pos + 2, $length, 'utf-8'),
+                        mb_substr($text, $pos + 1, $length, 'utf-8'),
                         $prevText
                     );
                 }

--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -243,9 +243,9 @@ class BaseDoc extends BaseObject
         $length = mb_strlen($text, 'utf-8');
         if ($length > 4 && ($pos = mb_strpos($text, '. ', 4, 'utf-8')) !== false) {
             $sentence = mb_substr($text, 0, $pos + 1, 'utf-8');
-            $prevText  = $prevText . $sentence;
+            $prevText  .= $sentence;
 
-            if ($length >= $pos + 3) {
+            if ($length >= $pos + 2) {
                 $abbrev = mb_substr($text, $pos - 3, 4, 'utf-8');
                 // do not break sentence after abbreviation
                 if ($abbrev === 'e.g.' ||

--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -240,19 +240,20 @@ class BaseDoc extends BaseObject
     public static function extractFirstSentence($text, $prevText = '')
     {
         $text = str_replace(["\r\n", "\n"], ' ', $text);
-        if (mb_strlen($text, 'utf-8') > 4 && ($pos = mb_strpos($text, '. ', 4, 'utf-8')) !== false) {
-            $sentence = mb_substr($text, 0, $pos + 1, 'utf-8');
+        $length = mb_strlen($text, 'utf-8');
+        if ($length > 4 && ($pos = mb_strpos($text, '. ', 4, 'utf-8')) !== false) {
+            $sentence = mb_substr($text, 0, $pos + 2, 'utf-8');
             $prevText  = $prevText . $sentence;
 
-            if (mb_strlen($text, 'utf-8') >= $pos + 3) {
-                $abbrev = mb_substr($text, $pos - 1, 4, 'utf-8');
+            if ($length >= $pos + 4) {
+                $abbrev = mb_substr($text, $pos - 2, 4, 'utf-8');
                 // do not break sentence after abbreviation
                 if ($abbrev === 'e.g.' ||
                     $abbrev === 'i.e.' ||
                     mb_substr_count($prevText, '`', 'utf-8') % 2 === 1
                 ) {
                     $sentence .= static::extractFirstSentence(
-                        mb_substr($text, $pos + 1, mb_strlen($text, 'utf-8'), 'utf-8'),
+                        mb_substr($text, $pos + 2, $length, 'utf-8'),
                         $prevText
                     );
                 }

--- a/models/BaseDoc.php
+++ b/models/BaseDoc.php
@@ -231,14 +231,16 @@ class BaseDoc extends BaseObject
     }
 
     /**
-     * Extracts first sentence out of text
+     * Extracts first sentence out of text.
+     *
      * @param string $text
      * @param string $prevText
      * @return string
      */
     public static function extractFirstSentence($text, $prevText = '')
     {
-        if (mb_strlen($text, 'utf-8') > 4 && ($pos = mb_strpos($text, '.', 4, 'utf-8')) !== false) {
+        $text = str_replace(["\r\n", "\n"], ' ', $text);
+        if (mb_strlen($text, 'utf-8') > 4 && ($pos = mb_strpos($text, '. ', 4, 'utf-8')) !== false) {
             $sentence = mb_substr($text, 0, $pos + 1, 'utf-8');
             $prevText  = $prevText . $sentence;
 

--- a/tests/models/BaseDocTest.php
+++ b/tests/models/BaseDocTest.php
@@ -12,16 +12,6 @@ use yii\apidoc\models\BaseDoc;
 
 class BaseDocTest extends TestCase
 {
-    public function testExtractFirstSentence()
-    {
-        $initialText = "a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or\n"
-            . 'URI template [RFC6570](https://tools.ietf.org/html/rfc6570). This property is required.';
-        $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
-        $expectedFirstSentence = 'a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or'
-            . ' URI template [RFC6570](https://tools.ietf.org/html/rfc6570).';
-        $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
-    }
-
     /**
      * @link https://github.com/yiisoft/yii2-apidoc/issues/128
      */
@@ -36,6 +26,19 @@ class BaseDocTest extends TestCase
         $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
         $expectedFirstSentence = 'fallback host info (e.g. `http://www.yiiframework.com`) used when '
             . '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid.';
+        $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
+    }
+    
+    /**
+     * @link https://github.com/yiisoft/yii2-apidoc/pull/282
+     */
+    public function testExtractFirstSentenceWithNewlineAndNoSpaceAfterDot()
+    {
+        $initialText = "a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or\n"
+            . 'URI template [RFC6570](https://tools.ietf.org/html/rfc6570). This property is required.';
+        $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
+        $expectedFirstSentence = 'a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or'
+            . ' URI template [RFC6570](https://tools.ietf.org/html/rfc6570).';
         $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
     }
 }

--- a/tests/models/BaseDocTest.php
+++ b/tests/models/BaseDocTest.php
@@ -12,6 +12,16 @@ use yii\apidoc\models\BaseDoc;
 
 class BaseDocTest extends TestCase
 {
+    public function testExtractFirstSentence()
+    {
+        $initialText = "a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or\n"
+            . 'URI template [RFC6570](https://tools.ietf.org/html/rfc6570). This property is required.';
+        $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
+        $expectedFirstSentence = 'a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or'
+            . ' URI template [RFC6570](https://tools.ietf.org/html/rfc6570).';
+        $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
+    }
+
     /**
      * @link https://github.com/yiisoft/yii2-apidoc/issues/128
      */
@@ -26,13 +36,6 @@ class BaseDocTest extends TestCase
         $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
         $expectedFirstSentence = 'fallback host info (e.g. `http://www.yiiframework.com`) used when '
             . '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid.';
-        $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
-        
-        $initialText = "a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or\n"
-            . 'URI template [RFC6570](https://tools.ietf.org/html/rfc6570). This property is required.';
-        $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
-        $expectedFirstSentence = 'a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or'
-            . ' URI template [RFC6570](https://tools.ietf.org/html/rfc6570).';
         $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
     }
 }

--- a/tests/models/BaseDocTest.php
+++ b/tests/models/BaseDocTest.php
@@ -17,15 +17,22 @@ class BaseDocTest extends TestCase
      */
     public function testExtractFirstSentenceWithBackticks()
     {
-        $initialText = 'fallback host info (e.g. `http://www.yiiframework.com`) used when ' .
-            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid. This value will replace ' .
-            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] before [[$denyCallback]] is called to make sure that ' .
-            'an invalid host will not be used for further processing. You can set it to `null` to leave ' .
-            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] untouched. Default value is empty string (this will ' .
-            'result creating relative URLs instead of absolute).';
+        $initialText = 'fallback host info (e.g. `http://www.yiiframework.com`) used when '
+            . '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid. This value will replace '
+            . '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] before [[$denyCallback]] is called to make sure that '
+            . 'an invalid host will not be used for further processing. You can set it to `null` to leave '
+            . '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] untouched. Default value is empty string (this will '
+            . 'result creating relative URLs instead of absolute).';
         $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
-        $expectedFirstSentence = 'fallback host info (e.g. `http://www.yiiframework.com`) used when ' .
-            '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid.';
+        $expectedFirstSentence = 'fallback host info (e.g. `http://www.yiiframework.com`) used when '
+            . '[[\yii\web\Request::$hostInfo|Request::$hostInfo]] is invalid.';
+        $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
+        
+        $initialText = "a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or\n"
+            . 'URI template [RFC6570](https://tools.ietf.org/html/rfc6570). This property is required.';
+        $actualFirstSentence = BaseDoc::extractFirstSentence($initialText);
+        $expectedFirstSentence = 'a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or'
+            . ' URI template [RFC6570](https://tools.ietf.org/html/rfc6570).';
         $this->assertEquals($expectedFirstSentence, $actualFirstSentence);
     }
 }


### PR DESCRIPTION
source comment:
~~~markdown
a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or
URI template [RFC6570](https://tools.ietf.org/html/rfc6570). This property is required.
~~~
before fix `BaseDoc::extractFirstSentence()` return:
`a URI [RFC3986](https://tools.`
after:
`a URI [RFC3986](https://tools.ietf.org/html/rfc3986) or URI template [RFC6570](https://tools.ietf.org/html/rfc6570).`
is dirty fix, but covering main cases

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

---

Minor additions for historical purposes by @arogachev.

Newline (only affects HTML code, not visual output):

https://github.com/yiisoft/yii2/blob/2874e070f3ad88c727b1335ba4f4515855bf5f64/framework/base/Controller.php#L48-L52
- https://www.yiiframework.com/doc/api/2.0/yii-base-controller

![Screenshot 2022-03-29 at 11-54-27 Controller yii_base_Controller](https://user-images.githubusercontent.com/8326201/160543023-51eb733b-dc5e-4cd5-bfbe-09f5c3456af1.png)

No space after dot:

- https://github.com/yiisoft/yii2/blob/2874e070f3ad88c727b1335ba4f4515855bf5f64/framework/web/Link.php#L25-L29
- https://www.yiiframework.com/doc/api/2.0/yii-web-link

![Screenshot 2022-03-29 at 11-49-16 Link yii_web_Link](https://user-images.githubusercontent.com/8326201/160542457-ae95cf81-74fb-430f-a839-e4fc4b186db6.png)