### PR TITLE
Fix `ApiMarkdown::renderLink()`

### DIFF
--- a/helpers/ApiMarkdown.php
+++ b/helpers/ApiMarkdown.php
@@ -139,7 +139,7 @@ class ApiMarkdown extends GithubMarkdown
         $linkHtml = parent::renderLink($block);
         // add special syntax for linking to the guide
         $guideLinkHtml = preg_replace_callback(
-            '/ href="guide:([^"]+)"/',
+            '/ href="guide:([^"]+)"/i',
             static function ($matches) {
                 return ' href="' . static::$renderer->generateGuideUrl($matches[1]) . '"';
             },
@@ -166,7 +166,7 @@ class ApiMarkdown extends GithubMarkdown
         }
 
         return preg_replace_callback(
-            '/ href="([^"]+)"/',
+            '/ href="([^"]+)"/i',
             static function ($matches) use ($repoUrl) {
                 return ' href="' . $repoUrl . '/' . $matches[1] . '"';
             },

--- a/helpers/ApiMarkdown.php
+++ b/helpers/ApiMarkdown.php
@@ -138,7 +138,7 @@ class ApiMarkdown extends GithubMarkdown
 
         $linkHtml = parent::renderLink($block);
         // add special syntax for linking to the guide
-        $guideLinkHtml = preg_replace_callback('/href="(guide:)?([-.#\w]+)"/i', function ($matches) {
+        $guideLinkHtml = preg_replace_callback('/href="(guide:)?(.+?)"/i', function ($matches) {
             return 'href="' . static::$renderer->generateGuideUrl($matches[2]) . '"';
         }, $linkHtml, 1);
         if ($guideLinkHtml !== $linkHtml) {

--- a/helpers/ApiMarkdown.php
+++ b/helpers/ApiMarkdown.php
@@ -138,8 +138,8 @@ class ApiMarkdown extends GithubMarkdown
 
         $linkHtml = parent::renderLink($block);
         // add special syntax for linking to the guide
-        $guideLinkHtml = preg_replace_callback('/href="guide:([A-z0-9-.#]+)"/i', function ($matches) {
-            return 'href="' . static::$renderer->generateGuideUrl($matches[1]) . '"';
+        $guideLinkHtml = preg_replace_callback('/href="(guide:)?([-.#\w]+)"/i', function ($matches) {
+            return 'href="' . static::$renderer->generateGuideUrl($matches[2]) . '"';
         }, $linkHtml, 1);
         if ($guideLinkHtml !== $linkHtml) {
             return $guideLinkHtml;
@@ -160,7 +160,7 @@ class ApiMarkdown extends GithubMarkdown
             return $linkHtml;
         }
 
-        return preg_replace_callback('/href="(.+)"/i', function ($matches) use ($repoUrl) {
+        return preg_replace_callback('/href="(.+?)"/i', function ($matches) use ($repoUrl) {
             return 'href="' . $repoUrl . '/' . $matches[1] . '"';
         }, $linkHtml, 1);
     }

--- a/helpers/ApiMarkdown.php
+++ b/helpers/ApiMarkdown.php
@@ -138,8 +138,8 @@ class ApiMarkdown extends GithubMarkdown
 
         $linkHtml = parent::renderLink($block);
         // add special syntax for linking to the guide
-        $guideLinkHtml = preg_replace_callback('/href="(guide:)?(.+?)"/i', function ($matches) {
-            return 'href="' . static::$renderer->generateGuideUrl($matches[2]) . '"';
+        $guideLinkHtml = preg_replace_callback('/href="guide:(.+?)"/i', function ($matches) {
+            return 'href="' . static::$renderer->generateGuideUrl($matches[1]) . '"';
         }, $linkHtml, 1);
         if ($guideLinkHtml !== $linkHtml) {
             return $guideLinkHtml;
@@ -161,7 +161,7 @@ class ApiMarkdown extends GithubMarkdown
         }
 
         return preg_replace_callback('/href="(.+?)"/i', function ($matches) use ($repoUrl) {
-            return 'href="' . $repoUrl . '/' . $matches[1] . '"';
+            return 'href="' . static::$renderer->generateGuideUrl($repoUrl . '/' . $matches[1]) . '"';
         }, $linkHtml, 1);
     }
 

--- a/helpers/ApiMarkdown.php
+++ b/helpers/ApiMarkdown.php
@@ -138,9 +138,14 @@ class ApiMarkdown extends GithubMarkdown
 
         $linkHtml = parent::renderLink($block);
         // add special syntax for linking to the guide
-        $guideLinkHtml = preg_replace_callback('/href="guide:(.+?)"/i', function ($matches) {
-            return 'href="' . static::$renderer->generateGuideUrl($matches[1]) . '"';
-        }, $linkHtml, 1);
+        $guideLinkHtml = preg_replace_callback(
+            '/ href="guide:([^"]+)"/',
+            static function ($matches) {
+                return ' href="' . static::$renderer->generateGuideUrl($matches[1]) . '"';
+            },
+            $linkHtml,
+            1
+        );
         if ($guideLinkHtml !== $linkHtml) {
             return $guideLinkHtml;
         }
@@ -160,9 +165,13 @@ class ApiMarkdown extends GithubMarkdown
             return $linkHtml;
         }
 
-        return preg_replace_callback('/href="(.+?)"/i', function ($matches) use ($repoUrl) {
-            return 'href="' . static::$renderer->generateGuideUrl($repoUrl . '/' . $matches[1]) . '"';
-        }, $linkHtml, 1);
+        return preg_replace_callback(
+            '/ href="([^"]+)"/',
+            static function ($matches) use ($repoUrl) {
+                return ' href="' . $repoUrl . '/' . $matches[1] . '"';
+            },
+            $linkHtml
+        );
     }
 
     /**


### PR DESCRIPTION
Normalizes `.md` URLs

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #286
