### PR TITLE
Deduplicate logged errors and warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 3.0.7 under development
 -----------------------
 
-- no changes in this release.
+- Enh #293: Deduplicate logged errors and warnings. (rhertogh)
 
 
 3.0.6 November 18, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 3.0.7 under development
 -----------------------
 
-- Enh #293: Deduplicate logged errors and warnings. (rhertogh)
+- Bug #293: Logged errors and warnings were duplicated in some cases (rhertogh)
 
 
 3.0.6 November 18, 2022

--- a/commands/ApiController.php
+++ b/commands/ApiController.php
@@ -125,24 +125,15 @@ class ApiController extends BaseController
         $renderer->controller = $this;
         $renderer->render($context, $targetDir);
 
-        $hashAlgo = in_array('xxh3', hash_algos()) ? 'xxh3' : 'crc32';
         if (!empty($context->errors)) {
-            $errors = [];
-            foreach ($context->errors as $error) {
-                $errors[hash($hashAlgo, json_encode($error))] = $error;
-            }
-            $errors = array_values($errors);
+            $errors = array_map('unserialize', array_unique(array_map('serialize', $context->errors)));
             ArrayHelper::multisort($errors, 'file');
             file_put_contents($targetDir . '/errors.txt', print_r($errors, true));
             $this->stdout(count($errors) . " errors have been logged to $targetDir/errors.txt\n", Console::FG_RED, Console::BOLD);
         }
 
         if (!empty($context->warnings)) {
-            $warnings = [];
-            foreach ($context->warnings as $warning) {
-                $warnings[hash($hashAlgo, json_encode($warning))] = $warning;
-            }
-            $warnings = array_values($warnings);
+            $warnings = array_map('unserialize', array_unique(array_map('serialize', $context->warnings)));
             ArrayHelper::multisort($warnings, 'file');
             file_put_contents($targetDir . '/warnings.txt', print_r($warnings, true));
             $this->stdout(count($warnings) . " warnings have been logged to $targetDir/warnings.txt\n", Console::FG_YELLOW, Console::BOLD);

--- a/commands/ApiController.php
+++ b/commands/ApiController.php
@@ -125,16 +125,27 @@ class ApiController extends BaseController
         $renderer->controller = $this;
         $renderer->render($context, $targetDir);
 
+        $hashAlgo = in_array('xxh3', hash_algos()) ? 'xxh3' : 'crc32';
         if (!empty($context->errors)) {
-            ArrayHelper::multisort($context->errors, 'file');
-            file_put_contents($targetDir . '/errors.txt', print_r($context->errors, true));
-            $this->stdout(count($context->errors) . " errors have been logged to $targetDir/errors.txt\n", Console::FG_RED, Console::BOLD);
+            $errors = [];
+            foreach ($context->errors as $error) {
+                $errors[hash($hashAlgo, json_encode($error))] = $error;
+            }
+            $errors = array_values($errors);
+            ArrayHelper::multisort($errors, 'file');
+            file_put_contents($targetDir . '/errors.txt', print_r($errors, true));
+            $this->stdout(count($errors) . " errors have been logged to $targetDir/errors.txt\n", Console::FG_RED, Console::BOLD);
         }
 
         if (!empty($context->warnings)) {
-            ArrayHelper::multisort($context->warnings, 'file');
-            file_put_contents($targetDir . '/warnings.txt', print_r($context->warnings, true));
-            $this->stdout(count($context->warnings) . " warnings have been logged to $targetDir/warnings.txt\n", Console::FG_YELLOW, Console::BOLD);
+            $warnings = [];
+            foreach ($context->warnings as $warning) {
+                $warnings[hash($hashAlgo, json_encode($warning))] = $warning;
+            }
+            $warnings = array_values($warnings);
+            ArrayHelper::multisort($warnings, 'file');
+            file_put_contents($targetDir . '/warnings.txt', print_r($warnings, true));
+            $this->stdout(count($warnings) . " warnings have been logged to $targetDir/warnings.txt\n", Console::FG_YELLOW, Console::BOLD);
         }
 
         return 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

The same error or warning might be logged multiple times. This PR deduplicate them before writing them to their respective files.