### PR TITLE
Fix running tests with filtering

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -126,7 +126,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function removeRuntimeDirectory()
     {
-        $runtimePath = Yii::getAlias('@runtime');
+        $runtimePath = Yii::getAlias('@runtime', false);
         if (empty($runtimePath)) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

When running tests with filtering, an error occurs because the alias `@runtime` is not defined.

<img width="1028" height="392" alt="image" src="https://github.com/user-attachments/assets/8b879b6a-2210-4012-9cc5-4231a5446ee1" />

