### PR TITLE
Add support for nullable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 apidoc extension Change Log
 - Enh #339: Add support for intersection types (mspirkov)
 - Bug #339: Fix the mechanism for replacing `static` with FQCN (mspirkov)
 - Bug #339: Fix processing of multidimensional arrays (mspirkov)
+- Enh #341: Add support for nullable types (mspirkov)
 
 
 3.0.8 November 24, 2025

--- a/renderers/BaseRenderer.php
+++ b/renderers/BaseRenderer.php
@@ -30,6 +30,8 @@ use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\InterfaceString;
 use phpDocumentor\Reflection\Types\Intersection;
 use phpDocumentor\Reflection\Types\Iterable_;
+use phpDocumentor\Reflection\Types\Null_;
+use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\Self_;
 use phpDocumentor\Reflection\Types\Static_;
@@ -288,6 +290,11 @@ abstract class BaseRenderer extends Component
 
                 if ($type instanceof Static_ && !$type->getGenericTypes() && $currentTypeDoc !== null) {
                     $links[] = $this->createTypeLink($currentTypeDoc, null, null, $options);
+                    continue;
+                }
+
+                if ($type instanceof Nullable) {
+                    $links[] = $this->createTypeLink([$type->getActualType(), new Null_()]);
                     continue;
                 }
 

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateBootstrap__3.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateBootstrap__3.html
@@ -379,6 +379,11 @@ yii\base\BaseObject</td>
                     <td><a href="yiiunit-apidoc-data-api-animal-dog.html">yiiunit\apidoc\data\api\animal\Dog</a></td>
                 </tr>
                                                 <tr class="">
+                    <td><a href="yiiunit-apidoc-data-api-animal-dog.html#getNullableString()-detail">getNullableString()</a></td>
+                    <td>Some description</td>
+                    <td><a href="yiiunit-apidoc-data-api-animal-dog.html">yiiunit\apidoc\data\api\animal\Dog</a></td>
+                </tr>
+                                                <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-animal-dog.html#getObjectShapeWithStaticGeneric()-detail">getObjectShapeWithStaticGeneric()</a></td>
                     <td></td>
                     <td><a href="yiiunit-apidoc-data-api-animal-dog.html">yiiunit\apidoc\data\api\animal\Dog</a></td>
@@ -1101,6 +1106,51 @@ yii\base\BaseObject</td>
                 <code class="hljs php language-php"><span class="hljs-keyword">public</span><span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-title">getNonEmptyListWithoutGenerics</span><span class="hljs-params">()</span>: <span class="hljs-title">array</span>
 </span>{
     <span class="hljs-keyword">return</span> [];
+}
+</code>
+            </pre>
+        </div>
+    </div>
+            
+        </div>
+            <div class="">
+            <div class="detail-header h3">
+                <a class="tool-link" title="go to top"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                <a class="tool-link hash" href="yiiunit-apidoc-data-api-animal-dog.html#getNullableString()-detail" title="direct link to this method"><span class="glyphicon icon-hash"></span></a>
+                
+                getNullableString()
+
+                <span class="detail-header-tag small">
+                    public                                                            method
+                                    </span>
+            </div>
+
+            
+            <div class="doc-description">
+                
+                <p><strong>Some description</strong></p>
+                                            </div>
+
+            <table class="detail-table table table-striped table-bordered table-hover">
+                <tr><td colspan="3" class="signature">
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span><strong><a href="yiiunit-apidoc-data-api-animal-dog.html#getNullableString()-detail">getNullableString</a></strong> ( )</td></tr>
+
+                            </table>
+
+            
+            
+
+    <p>
+        <a class="btn btn-link" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseGetNullableString">
+            Source code
+        </a>
+    </p>
+    <div class="collapse">
+        <div class="card card-body">
+            <pre>
+                <code class="hljs php language-php"><span class="hljs-keyword">public</span><span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-title">getNullableString</span><span class="hljs-params">()</span>: ?<span class="hljs-title">string</span>
+</span>{
+    <span class="hljs-keyword">return</span><span class="hljs-keyword">null</span>;
 }
 </code>
             </pre>

--- a/tests/data/api/animal/Dog.php
+++ b/tests/data/api/animal/Dog.php
@@ -123,4 +123,12 @@ class Dog extends Animal
     public function getStaticOrNull()
     {
     }
+
+    /**
+     * Some description
+     */
+    public function getNullableString(): ?string
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

### Before

No links were generated for such types.

<img width="1640" height="230" alt="image" src="https://github.com/user-attachments/assets/15cd4cdd-7af8-48f6-a925-20c510c30b93" />

The question mark also looks pretty ugly, especially when an FQCN is used instead of a `string`.

<img width="1116" height="168" alt="image" src="https://github.com/user-attachments/assets/fda8af43-2d9f-4177-8e9e-32aa7f887ce8" />

### After

Links are generated. The question mark is replaced with `null`.

<img width="1728" height="232" alt="image" src="https://github.com/user-attachments/assets/1a8a3db3-61a3-4eee-a51e-1f313440d26e" />
