### PR TITLE
Fix #384: Raise minimum `phpdocumentor/reflection` version to 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Yii Framework 2 apidoc extension Change Log
 - Chg #377: Raise minimum `phpdocumentor/type-resolver` version to 2.0 (mspirkov)
 - Chg #377: Raise minimum `nikic/php-parser` version to 5.0 (mspirkov)
 - Bug #381: Fix "All Classes" broken link (mspirkov)
+- Bug #384: Raise minimum `phpdocumentor/reflection` version to 7.0 (mspirkov)
 
 
 3.0.8 November 24, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Yii Framework 2 apidoc extension Change Log
 - Chg #377: Raise minimum `phpdocumentor/type-resolver` version to 2.0 (mspirkov)
 - Chg #377: Raise minimum `nikic/php-parser` version to 5.0 (mspirkov)
 - Bug #381: Fix "All Classes" broken link (mspirkov)
-- Bug #384: Raise minimum `phpdocumentor/reflection` version to 7.0 (mspirkov)
+- Chg #384: Raise minimum `phpdocumentor/reflection` version to 7.0 (mspirkov)
 
 
 3.0.8 November 24, 2025

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-mbstring": "*",
         "php": "^8.2",
         "yiisoft/yii2": "~2.0.16",
-        "phpdocumentor/reflection": "7.x-dev",
+        "phpdocumentor/reflection": "^7.0",
         "phpdocumentor/type-resolver": "^2.0",
         "nikic/php-parser": "^5.0",
         "cebe/js-search": "~0.9.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
