### PR TITLE
Fix #393: Suppress recoverable HTML parsing errors in API link titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 apidoc extension Change Log
 4.0.1 under development
 -----------------------
 
-- no changes in this release.
+- Bug #393: Suppress recoverable HTML parsing errors in API link titles (samdark)
 
 
 4.0.0 May 30, 2026

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -222,7 +222,13 @@ trait ApiMarkdownTrait
         }
 
         $doc = new DOMDocument();
-        @$doc->loadHTML($title);
+        set_error_handler(static fn (): bool => true, E_WARNING);
+        try {
+            $doc->loadHTML($title);
+        } finally {
+            restore_error_handler();
+        }
+
         $paragraph = $doc->getElementsByTagName('p')->item(0);
         if ($paragraph === null || $paragraph->firstChild === null) {
             return '';

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -221,13 +221,7 @@ trait ApiMarkdownTrait
         $previousHandler = null;
         $previousHandler = set_error_handler(
             static function (int $severity, string $message, string $file, int $line) use (&$previousHandler): bool {
-                if (str_starts_with($message, 'DOMDocument::loadHTML():')) {
-                    return true;
-                }
-
-                return $previousHandler === null
-                    ? false
-                    : $previousHandler($severity, $message, $file, $line);
+                return self::handleLoadHtmlWarning($previousHandler, $severity, $message, $file, $line);
             },
             E_WARNING,
         );
@@ -245,6 +239,25 @@ trait ApiMarkdownTrait
         $result = $paragraph->firstChild->C14N();
 
         return $result === false ? '' : $result;
+    }
+
+    /**
+     * @param callable|null $previousHandler
+     */
+    private static function handleLoadHtmlWarning(
+        $previousHandler,
+        int $severity,
+        string $message,
+        string $file,
+        int $line
+    ): bool {
+        if (str_starts_with($message, 'DOMDocument::loadHTML():')) {
+            return true;
+        }
+
+        return $previousHandler === null
+            ? false
+            : $previousHandler($severity, $message, $file, $line);
     }
 
     /**

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -217,10 +217,6 @@ trait ApiMarkdownTrait
         }
 
         $title = EncodingHelper::convertToUtf8WithHtmlEntities($title);
-        if ($title === '') {
-            return '';
-        }
-
         $doc = new DOMDocument();
         set_error_handler(static fn (): bool => true, E_WARNING);
         try {

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -242,10 +242,10 @@ trait ApiMarkdownTrait
     }
 
     /**
-     * @param callable|null $previousHandler
+     * @param (callable(int, string, string, int): bool)|null $previousHandler
      */
     private static function handleLoadHtmlWarning(
-        $previousHandler,
+        ?callable $previousHandler,
         int $severity,
         string $message,
         string $file,

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -221,17 +221,16 @@ trait ApiMarkdownTrait
             return '';
         }
 
-        $useInternalErrors = libxml_use_internal_errors(true);
-
-        try {
-            $doc = new DOMDocument();
-            $doc->loadHTML($title);
-
-            return $doc->getElementsByTagName('p')[0]->childNodes[0]->c14n();
-        } finally {
-            libxml_clear_errors();
-            libxml_use_internal_errors($useInternalErrors);
+        $doc = new DOMDocument();
+        @$doc->loadHTML($title);
+        $paragraph = $doc->getElementsByTagName('p')->item(0);
+        if ($paragraph === null || $paragraph->firstChild === null) {
+            return '';
         }
+
+        $result = $paragraph->firstChild->C14N();
+
+        return $result === false ? '' : $result;
     }
 
     /**

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -218,7 +218,19 @@ trait ApiMarkdownTrait
 
         $title = EncodingHelper::convertToUtf8WithHtmlEntities($title);
         $doc = new DOMDocument();
-        set_error_handler(static fn (): bool => true, E_WARNING);
+        $previousHandler = null;
+        $previousHandler = set_error_handler(
+            static function (int $severity, string $message, string $file, int $line) use (&$previousHandler): bool {
+                if (str_starts_with($message, 'DOMDocument::loadHTML():')) {
+                    return true;
+                }
+
+                return $previousHandler === null
+                    ? false
+                    : $previousHandler($severity, $message, $file, $line);
+            },
+            E_WARNING,
+        );
         try {
             $doc->loadHTML($title);
         } finally {

--- a/helpers/ApiMarkdownTrait.php
+++ b/helpers/ApiMarkdownTrait.php
@@ -212,11 +212,26 @@ trait ApiMarkdownTrait
         }
 
         $title = Markdown::process($title);
-        $title = EncodingHelper::convertToUtf8WithHtmlEntities($title);
-        $doc = new DOMDocument();
-        $doc->loadHTML($title);
+        if ($title === '') {
+            return '';
+        }
 
-        return $doc->getElementsByTagName('p')[0]->childNodes[0]->c14n();
+        $title = EncodingHelper::convertToUtf8WithHtmlEntities($title);
+        if ($title === '') {
+            return '';
+        }
+
+        $useInternalErrors = libxml_use_internal_errors(true);
+
+        try {
+            $doc = new DOMDocument();
+            $doc->loadHTML($title);
+
+            return $doc->getElementsByTagName('p')[0]->childNodes[0]->c14n();
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($useInternalErrors);
+        }
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: models/ConstDoc.php
 
 		-
-			message: '#^Property yii\\apidoc\\models\\TypeDoc\:\:\$events \(array\<string, yii\\apidoc\\models\\EventDoc\>\) does not accept array\<string, yii\\apidoc\\models\\ConstDoc\|yii\\apidoc\\models\\MethodDoc\|yii\\apidoc\\models\\PropertyDoc\>\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: models/Context.php
-
-		-
 			message: '#^Constructor of class yii\\apidoc\\models\\ParamDoc has an unused parameter \$context\.$#'
 			identifier: constructor.unusedParameter
 			count: 1
@@ -35,4 +29,3 @@ parameters:
 			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: renderers/BaseRenderer.php
-

--- a/tests/helpers/ApiMarkdownLinkTextTest.php
+++ b/tests/helpers/ApiMarkdownLinkTextTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\apidoc\helpers;
+
+use ErrorException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use yii\apidoc\helpers\ApiMarkdown;
+
+class ApiMarkdownLinkTextTest extends TestCase
+{
+    #[DataProvider('provideMalformedTitleData')]
+    public function testMalformedHtmlDoesNotRaiseWarnings(string $title, string $expected): void
+    {
+        $markdown = new class () extends ApiMarkdown {
+            public function renderLinkText(string $title): string
+            {
+                return $this->renderApiLinkText($title);
+            }
+        };
+
+        set_error_handler(
+            static fn (int $severity, string $message): bool => throw new ErrorException($message, 0, $severity),
+        );
+
+        try {
+            $this->assertSame($expected, $markdown->renderLinkText($title));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function provideMalformedTitleData(): array
+    {
+        return [
+            'PHP processing instruction' => ['<?php echo $value; ?>', ''],
+            'unescaped ampersand' => ['A & B', 'A &amp; B'],
+        ];
+    }
+}

--- a/tests/helpers/ApiMarkdownLinkTextTest.php
+++ b/tests/helpers/ApiMarkdownLinkTextTest.php
@@ -15,6 +15,11 @@ use yii\apidoc\helpers\ApiMarkdown;
 
 class ApiMarkdownLinkTextTest extends TestCase
 {
+    public function testIncompleteApiLinkRemainsText(): void
+    {
+        $this->assertSame('<p>[[</p>' . "\n", ApiMarkdown::process('[['));
+    }
+
     #[DataProvider('provideMalformedTitleData')]
     public function testMalformedHtmlDoesNotRaiseWarnings(string $title, ?string $expected): void
     {

--- a/tests/helpers/ApiMarkdownLinkTextTest.php
+++ b/tests/helpers/ApiMarkdownLinkTextTest.php
@@ -47,6 +47,8 @@ class ApiMarkdownLinkTextTest extends TestCase
     public static function provideMalformedTitleData(): array
     {
         return [
+            'whitespace' => [' ', ''],
+            'empty paragraph' => ['<p></p>', ''],
             // libxml preserves processing instructions differently across platforms.
             'PHP processing instruction' => ['<?php echo $value; ?>', null],
             'unescaped ampersand' => ['A & B', 'A &amp; B'],

--- a/tests/helpers/ApiMarkdownLinkTextTest.php
+++ b/tests/helpers/ApiMarkdownLinkTextTest.php
@@ -20,6 +20,31 @@ class ApiMarkdownLinkTextTest extends TestCase
         $this->assertSame('<p>[[</p>' . "\n", ApiMarkdown::process('[['));
     }
 
+    public function testPreviousErrorHandlerIsRestored(): void
+    {
+        $calls = 0;
+        set_error_handler(static function () use (&$calls): bool {
+            $calls++;
+
+            return true;
+        });
+
+        try {
+            $markdown = new class () extends ApiMarkdown {
+                public function renderLinkText(string $title): string
+                {
+                    return $this->renderApiLinkText($title);
+                }
+            };
+            $markdown->renderLinkText('A & B');
+            trigger_error('after DOM parsing', E_USER_WARNING);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(1, $calls);
+    }
+
     #[DataProvider('provideMalformedTitleData')]
     public function testMalformedHtmlDoesNotRaiseWarnings(string $title, ?string $expected): void
     {

--- a/tests/helpers/ApiMarkdownLinkTextTest.php
+++ b/tests/helpers/ApiMarkdownLinkTextTest.php
@@ -47,6 +47,7 @@ class ApiMarkdownLinkTextTest extends TestCase
     public static function provideMalformedTitleData(): array
     {
         return [
+            'empty title' => ['', ''],
             'whitespace' => [' ', ''],
             'empty paragraph' => ['<p></p>', ''],
             // libxml preserves processing instructions differently across platforms.

--- a/tests/helpers/ApiMarkdownLinkTextTest.php
+++ b/tests/helpers/ApiMarkdownLinkTextTest.php
@@ -16,7 +16,7 @@ use yii\apidoc\helpers\ApiMarkdown;
 class ApiMarkdownLinkTextTest extends TestCase
 {
     #[DataProvider('provideMalformedTitleData')]
-    public function testMalformedHtmlDoesNotRaiseWarnings(string $title, string $expected): void
+    public function testMalformedHtmlDoesNotRaiseWarnings(string $title, ?string $expected): void
     {
         $markdown = new class () extends ApiMarkdown {
             public function renderLinkText(string $title): string
@@ -30,19 +30,25 @@ class ApiMarkdownLinkTextTest extends TestCase
         );
 
         try {
-            $this->assertSame($expected, $markdown->renderLinkText($title));
+            $result = $markdown->renderLinkText($title);
+            if ($expected === null) {
+                $this->assertTrue($result === '' || str_contains($result, '$value'));
+            } else {
+                $this->assertSame($expected, $result);
+            }
         } finally {
             restore_error_handler();
         }
     }
 
     /**
-     * @return array<string, array{string, string}>
+     * @return array<string, array{string, string|null}>
      */
     public static function provideMalformedTitleData(): array
     {
         return [
-            'PHP processing instruction' => ['<?php echo $value; ?>', ''],
+            // libxml preserves processing instructions differently across platforms.
+            'PHP processing instruction' => ['<?php echo $value; ?>', null],
             'unescaped ampersand' => ['A & B', 'A &amp; B'],
         ];
     }

--- a/tests/helpers/ApiMarkdownLinkTextTest.php
+++ b/tests/helpers/ApiMarkdownLinkTextTest.php
@@ -11,6 +11,7 @@ namespace yiiunit\apidoc\helpers;
 use ErrorException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use yii\apidoc\helpers\ApiMarkdown;
 
 class ApiMarkdownLinkTextTest extends TestCase
@@ -43,6 +44,31 @@ class ApiMarkdownLinkTextTest extends TestCase
         }
 
         $this->assertSame(1, $calls);
+    }
+
+    public function testUnexpectedDomWarningIsDelegated(): void
+    {
+        $receivedMessage = null;
+        $previousHandler = static function (int $severity, string $message) use (&$receivedMessage): bool {
+            $receivedMessage = $message;
+
+            return true;
+        };
+        $method = new ReflectionMethod(ApiMarkdown::class, 'handleLoadHtmlWarning');
+
+        $result = $method->invoke(null, $previousHandler, E_WARNING, 'Unexpected warning', __FILE__, __LINE__);
+
+        $this->assertTrue($result);
+        $this->assertSame('Unexpected warning', $receivedMessage);
+    }
+
+    public function testUnexpectedDomWarningUsesPhpHandlingWithoutPreviousHandler(): void
+    {
+        $method = new ReflectionMethod(ApiMarkdown::class, 'handleLoadHtmlWarning');
+
+        $result = $method->invoke(null, null, E_WARNING, 'Unexpected warning', __FILE__, __LINE__);
+
+        $this->assertFalse($result);
     }
 
     #[DataProvider('provideMalformedTitleData')]


### PR DESCRIPTION
DOMDocument emits recoverable libxml diagnostics for API-link titles that contain HTML-like documentation fragments. Applications with an error handler may promote those warnings to errors, while cron runs receive noisy stderr even though parsing succeeds.

This enables libxml internal errors only around the title parsing call, clears the collected diagnostics, restores the caller's previous libxml setting, and handles titles that become empty during Markdown/entity conversion.

Tests cover PHP processing instructions and unescaped ampersands with PHP warnings promoted to exceptions.