### PR TITLE
Fix #394: Remove the bold formatting from the method names, add `<wbr>` to namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Yii Framework 2 apidoc extension Change Log
 4.0.1 under development
 -----------------------
 
-- no changes in this release.
+- Enh #394: Remove the bold formatting from the method names (mspirkov)
+- Enh #394: Add `<wbr>` to namespaces (mspirkov)
 
 
 4.0.0 May 30, 2026

--- a/templates/bootstrap/SideNavWidget.php
+++ b/templates/bootstrap/SideNavWidget.php
@@ -176,6 +176,8 @@ class SideNavWidget extends Widget
             Html::addCssClass($linkOptions, 'active');
         }
 
-        return Html::a($label, $url, $linkOptions) . $items;
+        $labelWithBreaks = str_replace('\\', '\\<wbr>', $label);
+
+        return Html::a($labelWithBreaks, $url, $linkOptions) . $items;
     }
 }

--- a/templates/html/ApiRenderer.php
+++ b/templates/html/ApiRenderer.php
@@ -289,7 +289,7 @@ class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
         }
 
         return '<span class="signature-defs">' . implode(' ', $definition) . '</span> '
-            . '<strong>' . $this->createSubjectLink($method, $method->name) . '</strong>'
+            . $this->createSubjectLink($method, $method->name)
             . str_replace('  ', ' ', '( ' . implode(', ', $params) . ' )')
             . ': <span class="signature-type">' . ($method->isReturnByReference ? '<b>&</b>' : '')
             . $this->createTypeLink($method->returnType, $method, null, [], $context) . '</span>';
@@ -355,9 +355,10 @@ class ApiRenderer extends BaseApiRenderer implements ViewContextInterface
      */
     protected function generateLink($text, $href, $options = [])
     {
+        $textWithBreaks = str_replace('\\', '\\<wbr>', $text);
         $options['href'] = $href;
 
-        return Html::a($text, null, $options);
+        return Html::a($textWithBreaks, null, $options);
     }
 
     /**

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__10.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__10.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,12 +122,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditional()-detail">conditional()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditionalForParameter()-detail">conditionalForParameter()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -162,7 +162,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditional()-detail">conditional</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;|<a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditional()-detail">conditional</a>( <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;|<a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -217,7 +217,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditionalForParameter()-detail">conditionalForParameter</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="https://www.php.net/language.types.object">object</a>&gt;</span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditionalForParameter()-detail">conditionalForParameter</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="https://www.php.net/language.types.object">object</a>&gt;</span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__11.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__11.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -84,7 +84,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-emptyclass.html">yiiunit\apidoc\data\api\classes\EmptyClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-emptyclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>EmptyClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__12.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__12.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -84,7 +84,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__13.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__13.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,7 +87,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -124,177 +124,177 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayWithKeyAndValueType-detail">$arrayWithKeyAndValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayWithValueType-detail">$arrayWithValueType</a></td>
                     <td>
 <a href="https://www.php.net/language.types.string">string</a>[]</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayWithoutGenerics-detail">$arrayWithoutGenerics</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithType-detail">$classStringWithType</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithoutType-detail">$classStringWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24intMask-detail">$intMask</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask</a>&lt;1, 2, 4&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24intMaskOf-detail">$intMaskOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask-of</a>&lt;1|2|4&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24intRange-detail">$intRange</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">int</a>&lt;1, max&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithType-detail">$interfaceStringWithType</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithoutType-detail">$interfaceStringWithoutType</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24iterableWithGenerics-detail">$iterableWithGenerics</a></td>
                     <td>
 <a href="https://www.php.net/language.types.iterable">iterable</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24iterableWithoutGenerics-detail">$iterableWithoutGenerics</a></td>
                     <td><a href="https://www.php.net/language.types.iterable">iterable</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24keyOf-detail">$keyOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#key-and-value-types-of-arrays-and-iterables">key-of</a>&lt;self::COLORS&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24listWithType-detail">$listWithType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">list</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24listWithoutType-detail">$listWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">list</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyArrayWithKeyAndValueType-detail">$nonEmptyArrayWithKeyAndValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyArrayWithValueType-detail">$nonEmptyArrayWithValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyArrayWithoutGenerics-detail">$nonEmptyArrayWithoutGenerics</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyListWithType-detail">$nonEmptyListWithType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">non-empty-list</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyListWithoutType-detail">$nonEmptyListWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">non-empty-list</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24privatePropertiesOf-detail">$privatePropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24propertiesOf-detail">$propertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24publicPropertiesOf-detail">$publicPropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24valueOf-detail">$valueOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#key-and-value-types-of-arrays-and-iterables">value-of</a>&lt;self::COLORS&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -321,27 +321,27 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getClassWithGenerics()-detail">getClassWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithGenerics()-detail">getSelfWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithGenerics()-detail">getStaticWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -378,7 +378,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>COLOR_GREY</td>
@@ -386,7 +386,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>COLOR_WHITE</td>
@@ -394,7 +394,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -423,7 +423,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -515,7 +515,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithType-detail">$classStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithType-detail">$classStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -630,7 +630,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithType-detail">$interfaceStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithType-detail">$interfaceStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -906,7 +906,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24privatePropertiesOf-detail">$privatePropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24privatePropertiesOf-detail">$privatePropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -929,7 +929,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24propertiesOf-detail">$propertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24propertiesOf-detail">$propertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -952,7 +952,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -975,7 +975,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24publicPropertiesOf-detail">$publicPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24publicPropertiesOf-detail">$publicPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -1030,7 +1030,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getClassWithGenerics()-detail">getClassWithGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getClassWithGenerics()-detail">getClassWithGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1075,7 +1075,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithGenerics()-detail">getSelfWithGenerics</a></strong>( ): <span class="signature-type">self&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithGenerics()-detail">getSelfWithGenerics</a>( ): <span class="signature-type">self&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1120,7 +1120,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics</a></strong>( ): <span class="signature-type">self</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics</a>( ): <span class="signature-type">self</span>
 </td></tr>
 
                             </table>
@@ -1165,7 +1165,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithGenerics()-detail">getStaticWithGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithGenerics()-detail">getStaticWithGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1210,7 +1210,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__14.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__14.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,7 +87,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -125,7 +125,7 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#%24someProperty-detail">$someProperty</a></td>
                     <td></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -152,17 +152,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#guideLink()-detail">guideLink()</a></td>
                     <td>See the <a href="/guide-concept-aliases.html#defining-aliases">aliases section</a> of the guide.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">inlineLink()</a></td>
                     <td>Some description. See <a href="https://docs.phpdoc.org/guide/references/phpdoc/tags/link.html">documentation</a>.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineSee()-detail">inlineSee()</a></td>
                     <td>Some description. See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">parent method</a>.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -196,7 +196,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -257,7 +257,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#guideLink()-detail">guideLink</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#guideLink()-detail">guideLink</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -304,7 +304,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">inlineLink</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">inlineLink</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -345,12 +345,12 @@
             <div class="doc-description">
                 
                                     <p><strong>Some description. See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">parent method</a>.</strong></p>
-                    <p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#SOME_CONST-detail">yiiunit\apidoc\data\api\classes\InlineTags::SOME_CONST</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#%24someProperty-detail">yiiunit\apidoc\data\api\classes\InlineTags::$someProperty</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>.</p>
+                    <p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#SOME_CONST-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::SOME_CONST</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#%24someProperty-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::$someProperty</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>.</p>
 <p>See <a href="https://www.php.net/manual/intro.filter.php">documentation</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">yiiunit\apidoc\data\api\classes\InlineTags::inlineLink()</a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::inlineLink()</wbr></wbr></wbr></wbr></wbr></a>.</p>
 <p>See <a href="https://www.php.net/class.arrayaccess">ArrayAccess</a>.</p>
 <p>See <a href="https://www.php.net/manual/en/function.in-array.php">in_array()</a>.</p>
 <p>See <a href="https://www.php.net/manual/en/function.in-array.php">in_array()</a>.</p>
@@ -360,7 +360,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineSee()-detail">inlineSee</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineSee()-detail">inlineSee</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__15.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__15.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,17 +122,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24basic-detail">$basic</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a>
+<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24withGenerics-detail">$withGenerics</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
+<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -167,7 +167,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24basic-detail">$basic</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24basic-detail">$basic</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -190,7 +190,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24withGenerics-detail">$withGenerics</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24withGenerics-detail">$withGenerics</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__16.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__16.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -125,7 +125,7 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#%24invalidVar-detail">$invalidVar</a></td>
                     <td></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -152,7 +152,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#invalidParamAndReturn()-detail">invalidParamAndReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -216,7 +216,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#invalidParamAndReturn()-detail">invalidParamAndReturn</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#invalidParamAndReturn()-detail">invalidParamAndReturn</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__17.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__17.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,17 +122,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getGenericTypes()-detail">getGenericTypes()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getIntWithParams()-detail">getIntWithParams()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getMixedWithoutParams()-detail">getMixedWithoutParams()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -167,14 +167,14 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getGenericTypes()-detail">getGenericTypes</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getGenericTypes()-detail">getGenericTypes</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span>
 </td></tr>
 
                                     
                                             <tr>
                             <th class="param-name-col">return</th>
                             <td class="param-type-col">
-<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
+<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                             <td class="param-desc-col">
                                                             </td>
                         </tr>
@@ -205,7 +205,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getIntWithParams()-detail">getIntWithParams</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$test</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$test2</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$test3</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getIntWithParams()-detail">getIntWithParams</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$test</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$test2</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$test3</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span>
 </td></tr>
 
                                                             <tr>
@@ -262,7 +262,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getMixedWithoutParams()-detail">getMixedWithoutParams</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getMixedWithoutParams()-detail">getMixedWithoutParams</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__18.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__18.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -143,12 +143,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getNameFromSomeData()-detail">getNameFromSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getSomeField()-detail">getSomeField()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -183,7 +183,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getNameFromSomeData()-detail">getNameFromSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#phpstan-type-SomeData">SomeData</a>["name"]</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getNameFromSomeData()-detail">getNameFromSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#phpstan-type-SomeData">SomeData</a>["name"]</span>
 </td></tr>
 
                             </table>
@@ -228,7 +228,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getSomeField()-detail">getSomeField</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><span style="color: #0000BB">$array</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getSomeField()-detail">getSomeField</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><span style="color: #0000BB">$array</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__19.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__19.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -124,115 +124,115 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24arrayKey-detail">$arrayKey</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24callableArray-detail">$callableArray</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#callable-arrays">callable-array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24callableString-detail">$callableString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">callable-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24closedResource-detail">$closedResource</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">closed-resource</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24enumString-detail">$enumString</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#enum-string">enum-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24literalString-detail">$literalString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">literal-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24lowercaseString-detail">$lowercaseString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">lowercase-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24negativeInt-detail">$negativeInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">negative-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonEmptyString-detail">$nonEmptyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">non-empty-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonFalsyString-detail">$nonFalsyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">non-falsy-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonNegativeInt-detail">$nonNegativeInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-negative-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonPositiveInt-detail">$nonPositiveInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-positive-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonZeroInt-detail">$nonZeroInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-zero-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24numericString-detail">$numericString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">numeric-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24openResource-detail">$openResource</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">open-resource</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24positiveInt-detail">$positiveInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">positive-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24scalar-detail">$scalar</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">scalar</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24traitString-detail">$traitString</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#trait-string">trait-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24truthyString-detail">$truthyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">truthy-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -259,32 +259,32 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getFalse()-detail">getFalse()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getThis()-detail">getThis()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getTrue()-detail">getTrue()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturn()-detail">neverReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturns()-detail">neverReturns()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#noReturn()-detail">noReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -763,7 +763,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getFalse()-detail">getFalse</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">false</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getFalse()-detail">getFalse</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">false</a></span>
 </td></tr>
 
                             </table>
@@ -808,7 +808,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getThis()-detail">getThis</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-othertypes.html">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getThis()-detail">getThis</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-othertypes.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -853,7 +853,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getTrue()-detail">getTrue</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">true</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getTrue()-detail">getTrue</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">true</a></span>
 </td></tr>
 
                             </table>
@@ -898,7 +898,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturn()-detail">neverReturn</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-return</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturn()-detail">neverReturn</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-return</a></span>
 </td></tr>
 
                             </table>
@@ -943,7 +943,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturns()-detail">neverReturns</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-returns</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturns()-detail">neverReturns</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-returns</a></span>
 </td></tr>
 
                             </table>
@@ -988,7 +988,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#noReturn()-detail">noReturn</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">no-return</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#noReturn()-detail">noReturn</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">no-return</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__20.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__20.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -121,22 +121,22 @@
 
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24classWrite-detail">$classWrite</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24int-detail">$int</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24intMaskRead-detail">$intMaskRead</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask</a>&lt;1, 2, 4&gt;</td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -171,7 +171,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></span><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24classWrite-detail">$classWrite</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24classWrite-detail">$classWrite</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__21.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__21.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -175,17 +175,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPsalmType()-detail">getOnlyPsalmType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getSomeData()-detail">getSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -220,7 +220,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
 </td></tr>
 
                             </table>
@@ -265,7 +265,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
 </td></tr>
 
                             </table>
@@ -310,7 +310,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getSomeData()-detail">getSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getSomeData()-detail">getSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__22.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__22.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,17 +122,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPsalmType()-detail">getOnlyPsalmType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getSomeData()-detail">getSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -167,7 +167,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
 </td></tr>
 
                             </table>
@@ -212,7 +212,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
 </td></tr>
 
                             </table>
@@ -257,7 +257,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getSomeData()-detail">getSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getSomeData()-detail">getSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__23.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__23.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -124,42 +124,42 @@
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{0: <a href="https://www.php.net/language.types.string">string</a>, 1?: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24arrayWithStringKeys-detail">$arrayWithStringKeys</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{name: <a href="https://www.php.net/language.types.string">string</a>, value?: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24arrayWithoutKeys-detail">$arrayWithoutKeys</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24listWithKeys-detail">$listWithKeys</a></td>
                     <td>
 <a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#list-shapes">list</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24listWithoutKeys-detail">$listWithoutKeys</a></td>
                     <td>
 <a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#list-shapes">list</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24object-detail">$object</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#object-shapes">object</a>{name: <a href="https://www.php.net/language.types.string">string</a>, value: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__24.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__24.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\apidoc\data\api\classes\Templates</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -125,7 +125,7 @@
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\apidoc\data\api\classes\Templates</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -152,7 +152,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-templates.html#getSomeField()-detail">getSomeField()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\apidoc\data\api\classes\Templates</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -217,7 +217,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-templates.html#getSomeField()-detail">getSomeField</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-templates.html#getSomeField()-detail">getSomeField</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__25.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__25.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,7 +87,7 @@
                                 <tr>
 <th>Implemented by</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a>, <a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a>, <a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\apidoc\data\api\interfaces\SubInterface</a>
+<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                     </table>
@@ -125,7 +125,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -159,7 +159,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -190,7 +190,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__26.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__26.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
                     <tr>
 <th>Extends</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                 </table>
 
@@ -123,7 +123,7 @@
                                     <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -157,7 +157,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>SUB_INTERFACE_CONSTANT</td>
@@ -165,7 +165,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\apidoc\data\api\interfaces\SubInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -192,14 +192,14 @@
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\apidoc\data\api\interfaces\BaseInterface::baseMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface::baseMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__27.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__27.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -88,7 +88,7 @@
                                     <tr>
 <th>Implemented by</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 </table>
@@ -127,7 +127,7 @@
                     <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -154,7 +154,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -188,7 +188,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -249,7 +249,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__28.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__28.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
                         <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                             </table>
 
@@ -122,7 +122,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-traits-childtrait.html#childTraitMethod()-detail">childTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-childtrait.html">yiiunit\apidoc\data\api\traits\ChildTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-childtrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>ChildTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -157,7 +157,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-childtrait.html#childTraitMethod()-detail">childTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-childtrait.html#childTraitMethod()-detail">childTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__3.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__3.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,16 +86,16 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                         <tr>
 <th>Subclasses</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                         </table>
@@ -105,8 +105,8 @@
     
     <p>See also:</p>
 <ul>
-<li><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></li>
-<li><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\apidoc\data\api\interfaces\SubInterface</a></li>
+<li><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></li>
+<li><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a></li>
 </ul>
 </div>
 
@@ -152,12 +152,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -191,7 +191,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -222,7 +222,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">$this</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -261,14 +261,14 @@
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\apidoc\data\api\interfaces\BaseInterface::baseMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface::baseMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__4.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__4.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -89,21 +89,21 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                     <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                 <tr>
 <th>Subclasses</th>
-<td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                         <tr>
 <th>Available since version</th>
@@ -116,7 +116,7 @@
     <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when
 an unknown printer took a galley of type and scrambled it to make a type specimen book.</p>
 
-    <p>See also <a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a> description.</p>
+    <p>See also <a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a> description.</p>
 </div>
 
 
@@ -148,25 +148,25 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24baseClassProperty-detail">$baseClassProperty</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24deprecatedBaseClassProperty-detail">$deprecatedBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24deprecatedSinceBaseClassProperty-detail">$deprecatedSinceBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -193,52 +193,52 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#__construct()-detail">__construct()</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions()</a></td>
                     <td>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -266,24 +266,24 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#DEPRECATED_EVENT-detail">DEPRECATED_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#DEPRECATED_SINCE_EVENT-detail">DEPRECATED_SINCE_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#EVENT-detail">EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -315,7 +315,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>BASE_TRAIT_CONST</td>
@@ -323,7 +323,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>DEPRECATED_CONST</td>
@@ -335,7 +335,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>DEPRECATED_SINCE_CONST</td>
@@ -347,7 +347,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           since version 2.2.0: description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -467,7 +467,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#__construct()-detail">__construct</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;</span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#__construct()-detail">__construct</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;</span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -521,7 +521,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-baseclass.html">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-baseclass.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -566,7 +566,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
@@ -621,14 +621,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\apidoc\data\api\traits\BaseTrait::baseTraitMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait::baseTraitMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -679,7 +679,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -726,7 +726,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -771,7 +771,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     
@@ -824,7 +824,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -872,7 +872,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -916,7 +916,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -956,7 +956,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 DEPRECATED_EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
                             <div class="doc-description deprecated">
@@ -981,7 +981,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 DEPRECATED_SINCE_EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
                             <div class="doc-description deprecated">
@@ -1006,7 +1006,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__5.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__5.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,8 +87,8 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a> &raquo;
-<a href="yii-base-baseobject.html">yii\base\BaseObject</a>
+<a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yii-base-baseobject.html">yii\<wbr>base\<wbr>BaseObject</wbr></wbr></a>
 </td>
 </tr>
                                         </table>
@@ -127,13 +127,13 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#%24onlyRead-detail">$onlyRead</a></td>
                     <td><a href="https://www.php.net/language.types.mixed">mixed</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#%24onlyWrite-detail">$onlyWrite</a></td>
                     <td><a href="https://www.php.net/language.types.mixed">mixed</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#%24readableAndWritable-detail">$readableAndWritable</a></td>
@@ -141,7 +141,7 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -168,22 +168,22 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -215,7 +215,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -237,7 +237,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -259,7 +259,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span><br><span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span><br><span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -291,7 +291,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                             </table>
@@ -336,7 +336,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                             </table>
@@ -381,7 +381,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -434,7 +434,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__6.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__6.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -123,39 +123,39 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24intDocType-detail">$intDocType</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24intTypeHint-detail">$intTypeHint</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArray-detail">$multidimensionalArray</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>[]</td>
+<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>[]</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nativeClassDocType-detail">$nativeClassDocType</a></td>
                     <td><a href="https://www.php.net/class.exception">Exception</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nativeClassTypeHint-detail">$nativeClassTypeHint</a></td>
                     <td><a href="https://www.php.net/class.exception">Exception</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nullableDocType-detail">$nullableDocType</a></td>
@@ -163,7 +163,7 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nullableTypeHint-detail">$nullableTypeHint</a></td>
@@ -171,31 +171,31 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24stringDocType-detail">$stringDocType</a></td>
                     <td><a href="https://www.php.net/language.types.string">string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24stringTypeHint-detail">$stringTypeHint</a></td>
                     <td><a href="https://www.php.net/language.types.string">string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassDocType-detail">$userClassDocType</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassTypeHint-detail">$userClassTypeHint</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -276,7 +276,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>[]</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArray-detail">$multidimensionalArray</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>[]</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArray-detail">$multidimensionalArray</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -299,7 +299,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -460,7 +460,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassDocType-detail">$userClassDocType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassDocType-detail">$userClassDocType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -483,7 +483,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassTypeHint-detail">$userClassTypeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassTypeHint-detail">$userClassTypeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__7.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__7.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,32 +122,32 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedCallableDocType()-detail">advancedCallableDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedClosureDocType()-detail">advancedClosureDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableDocType()-detail">callableDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableTypeHint()-detail">callableTypeHint()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureDocType()-detail">closureDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureTypeHint()-detail">closureTypeHint()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -182,13 +182,13 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedCallableDocType()-detail">advancedCallableDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedCallableDocType()-detail">advancedCallableDocType</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
                             <td class="param-name-col"><span style="color: #0000BB">$docType</span></td>
                             <td class="param-type-col">
-<a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
+<a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
 </td>
                             <td class="param-desc-col">
                                                            </td>
@@ -237,13 +237,13 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedClosureDocType()-detail">advancedClosureDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedClosureDocType()-detail">advancedClosureDocType</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
                             <td class="param-name-col"><span style="color: #0000BB">$docType</span></td>
                             <td class="param-type-col">
-<a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
+<a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
 </td>
                             <td class="param-desc-col">
                                                            </td>
@@ -292,7 +292,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableDocType()-detail">callableDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableDocType()-detail">callableDocType</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
 </td></tr>
 
                                                             <tr>
@@ -345,7 +345,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableTypeHint()-detail">callableTypeHint</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableTypeHint()-detail">callableTypeHint</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
 </td></tr>
 
                                                             <tr>
@@ -398,7 +398,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureDocType()-detail">closureDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureDocType()-detail">closureDocType</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
 </td></tr>
 
                                                             <tr>
@@ -451,7 +451,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureTypeHint()-detail">closureTypeHint</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureTypeHint()-detail">closureTypeHint</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__8.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__8.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -89,18 +89,18 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a>
+<a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                     <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                             </table>
 
@@ -141,31 +141,31 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24baseClassProperty-detail">$baseClassProperty</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24childProperty-detail">$childProperty</a></td>
                     <td></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24deprecatedBaseClassProperty-detail">$deprecatedBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24deprecatedSinceBaseClassProperty-detail">$deprecatedSinceBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -192,57 +192,57 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#__construct()-detail">__construct()</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#childMethod()-detail">childMethod()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#deprecatedMethod()-detail">deprecatedMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions()</a></td>
                     <td>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithThrows()-detail">methodWithThrows()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithTodoTag()-detail">methodWithTodoTag()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -270,24 +270,24 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#DEPRECATED_EVENT-detail">DEPRECATED_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#DEPRECATED_SINCE_EVENT-detail">DEPRECATED_SINCE_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#EVENT-detail">EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -319,7 +319,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>BASE_TRAIT_CONST</td>
@@ -327,7 +327,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>DEPRECATED_CONST</td>
@@ -339,7 +339,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>DEPRECATED_SINCE_CONST</td>
@@ -351,7 +351,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           since version 2.2.0: description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -435,7 +435,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass.html#__construct()-detail">__construct</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span>, <span class="signature-type"><a href="https://www.php.net/language.types.array">array</a></span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass.html#__construct()-detail">__construct</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span>, <span class="signature-type"><a href="https://www.php.net/language.types.array">array</a></span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -490,14 +490,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">yiiunit\apidoc\data\api\classes\BaseClass::abstractMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::abstractMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-childclass.html">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-childclass.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -542,7 +542,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
@@ -598,14 +598,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\apidoc\data\api\traits\BaseTrait::baseTraitMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait::baseTraitMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -649,7 +649,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass.html#childMethod()-detail">childMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass.html#childMethod()-detail">childMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"></span>
 </td></tr>
 
                                                             <tr>
@@ -704,14 +704,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">yiiunit\apidoc\data\api\classes\BaseClass::deprecatedMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::deprecatedMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -752,7 +752,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithShortAndDetailedDescriptions()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithShortAndDetailedDescriptions()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</strong></p>
                     <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when
@@ -761,7 +761,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -802,14 +802,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithThrows()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithThrows()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     
@@ -858,14 +858,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithTodoTag()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithTodoTag()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -910,13 +910,13 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithoutDescriptions()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithoutDescriptions()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                             </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -957,13 +957,13 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithoutDocBlock()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithoutDocBlock()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                             </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__9.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set bootstrap__9.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,18 +122,18 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24docType-detail">$docType</a></td>
                     <td>
-<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a>
+<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24typeHint-detail">$typeHint</a></td>
                     <td>
-<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a>
+<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -168,7 +168,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24docType-detail">$docType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24docType-detail">$docType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -191,7 +191,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24typeHint-detail">$typeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24typeHint-detail">$typeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__10.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__10.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -49,12 +49,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes#conditional()-detail">conditional()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes#conditionalForParameter()-detail">conditionalForParameter()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -89,7 +89,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-conditionaltypes#conditional()-detail">conditional</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;|<a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-conditionaltypes#conditional()-detail">conditional</a>( <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;|<a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -144,7 +144,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-conditionaltypes#conditionalForParameter()-detail">conditionalForParameter</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="https://www.php.net/language.types.object">object</a>&gt;</span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-conditionaltypes#conditionalForParameter()-detail">conditionalForParameter</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="https://www.php.net/language.types.object">object</a>&gt;</span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__11.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__11.html
@@ -11,7 +11,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-emptyclass">yiiunit\apidoc\data\api\classes\EmptyClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-emptyclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>EmptyClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__12.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__12.html
@@ -11,7 +11,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__13.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__13.html
@@ -14,7 +14,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -51,177 +51,177 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24arrayWithKeyAndValueType-detail">$arrayWithKeyAndValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24arrayWithValueType-detail">$arrayWithValueType</a></td>
                     <td>
 <a href="https://www.php.net/language.types.string">string</a>[]</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24arrayWithoutGenerics-detail">$arrayWithoutGenerics</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24classStringWithType-detail">$classStringWithType</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24classStringWithoutType-detail">$classStringWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24intMask-detail">$intMask</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask</a>&lt;1, 2, 4&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24intMaskOf-detail">$intMaskOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask-of</a>&lt;1|2|4&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24intRange-detail">$intRange</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">int</a>&lt;1, max&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24interfaceStringWithType-detail">$interfaceStringWithType</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24interfaceStringWithoutType-detail">$interfaceStringWithoutType</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24iterableWithGenerics-detail">$iterableWithGenerics</a></td>
                     <td>
 <a href="https://www.php.net/language.types.iterable">iterable</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24iterableWithoutGenerics-detail">$iterableWithoutGenerics</a></td>
                     <td><a href="https://www.php.net/language.types.iterable">iterable</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24keyOf-detail">$keyOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#key-and-value-types-of-arrays-and-iterables">key-of</a>&lt;self::COLORS&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24listWithType-detail">$listWithType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">list</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24listWithoutType-detail">$listWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">list</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24nonEmptyArrayWithKeyAndValueType-detail">$nonEmptyArrayWithKeyAndValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24nonEmptyArrayWithValueType-detail">$nonEmptyArrayWithValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24nonEmptyArrayWithoutGenerics-detail">$nonEmptyArrayWithoutGenerics</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24nonEmptyListWithType-detail">$nonEmptyListWithType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">non-empty-list</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24nonEmptyListWithoutType-detail">$nonEmptyListWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">non-empty-list</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24privatePropertiesOf-detail">$privatePropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24propertiesOf-detail">$propertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24publicPropertiesOf-detail">$publicPropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#%24valueOf-detail">$valueOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#key-and-value-types-of-arrays-and-iterables">value-of</a>&lt;self::COLORS&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -248,27 +248,27 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#getClassWithGenerics()-detail">getClassWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#getSelfWithGenerics()-detail">getSelfWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#getStaticWithGenerics()-detail">getStaticWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -305,7 +305,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>COLOR_GREY</td>
@@ -313,7 +313,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>COLOR_WHITE</td>
@@ -321,7 +321,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -350,7 +350,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -442,7 +442,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24classStringWithType-detail">$classStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24classStringWithType-detail">$classStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -557,7 +557,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24interfaceStringWithType-detail">$interfaceStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24interfaceStringWithType-detail">$interfaceStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -833,7 +833,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24privatePropertiesOf-detail">$privatePropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24privatePropertiesOf-detail">$privatePropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -856,7 +856,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24propertiesOf-detail">$propertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24propertiesOf-detail">$propertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -879,7 +879,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -902,7 +902,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24publicPropertiesOf-detail">$publicPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes#%24publicPropertiesOf-detail">$publicPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -957,7 +957,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes#getClassWithGenerics()-detail">getClassWithGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes#getClassWithGenerics()-detail">getClassWithGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1002,7 +1002,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes#getSelfWithGenerics()-detail">getSelfWithGenerics</a></strong>( ): <span class="signature-type">self&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes#getSelfWithGenerics()-detail">getSelfWithGenerics</a>( ): <span class="signature-type">self&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1047,7 +1047,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics</a></strong>( ): <span class="signature-type">self</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics</a>( ): <span class="signature-type">self</span>
 </td></tr>
 
                             </table>
@@ -1092,7 +1092,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes#getStaticWithGenerics()-detail">getStaticWithGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes#getStaticWithGenerics()-detail">getStaticWithGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1137,7 +1137,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__14.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__14.html
@@ -14,7 +14,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -52,7 +52,7 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags#%24someProperty-detail">$someProperty</a></td>
                     <td></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -79,17 +79,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags#guideLink()-detail">guideLink()</a></td>
                     <td>See the <a href="/guide-concept-aliases.html#defining-aliases">aliases section</a> of the guide.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineLink()-detail">inlineLink()</a></td>
                     <td>Some description. See <a href="https://docs.phpdoc.org/guide/references/phpdoc/tags/link.html">documentation</a>.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineSee()-detail">inlineSee()</a></td>
                     <td>Some description. See <a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineLink()-detail">parent method</a>.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -123,7 +123,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -184,7 +184,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags#guideLink()-detail">guideLink</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags#guideLink()-detail">guideLink</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -231,7 +231,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineLink()-detail">inlineLink</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineLink()-detail">inlineLink</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -272,12 +272,12 @@
             <div class="doc-description">
                 
                                     <p><strong>Some description. See <a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineLink()-detail">parent method</a>.</strong></p>
-                    <p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags#SOME_CONST-detail">yiiunit\apidoc\data\api\classes\InlineTags::SOME_CONST</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags#%24someProperty-detail">yiiunit\apidoc\data\api\classes\InlineTags::$someProperty</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>.</p>
+                    <p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags#SOME_CONST-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::SOME_CONST</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags#%24someProperty-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::$someProperty</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>.</p>
 <p>See <a href="https://www.php.net/manual/intro.filter.php">documentation</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineLink()-detail">yiiunit\apidoc\data\api\classes\InlineTags::inlineLink()</a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineLink()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::inlineLink()</wbr></wbr></wbr></wbr></wbr></a>.</p>
 <p>See <a href="https://www.php.net/class.arrayaccess">ArrayAccess</a>.</p>
 <p>See <a href="https://www.php.net/manual/en/function.in-array.php">in_array()</a>.</p>
 <p>See <a href="https://www.php.net/manual/en/function.in-array.php">in_array()</a>.</p>
@@ -287,7 +287,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineSee()-detail">inlineSee</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags#inlineSee()-detail">inlineSee</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__15.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__15.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -49,17 +49,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes#%24basic-detail">$basic</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a>
+<a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes#%24withGenerics-detail">$withGenerics</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
+<a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -94,7 +94,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\apidoc\data\api\classes\InlineTags</a></span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes#%24basic-detail">$basic</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes#%24basic-detail">$basic</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -117,7 +117,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes#%24withGenerics-detail">$withGenerics</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes#%24withGenerics-detail">$withGenerics</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__16.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__16.html
@@ -13,7 +13,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-invalidtags">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-invalidtags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -52,7 +52,7 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-invalidtags#%24invalidVar-detail">$invalidVar</a></td>
                     <td></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -79,7 +79,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-invalidtags#invalidParamAndReturn()-detail">invalidParamAndReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -143,7 +143,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-invalidtags#invalidParamAndReturn()-detail">invalidParamAndReturn</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-invalidtags#invalidParamAndReturn()-detail">invalidParamAndReturn</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__17.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__17.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -49,17 +49,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags#getGenericTypes()-detail">getGenericTypes()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags#getIntWithParams()-detail">getIntWithParams()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags#getMixedWithoutParams()-detail">getMixedWithoutParams()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -94,14 +94,14 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags#getGenericTypes()-detail">getGenericTypes</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags#getGenericTypes()-detail">getGenericTypes</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span>
 </td></tr>
 
                                     
                                             <tr>
                             <th class="param-name-col">return</th>
                             <td class="param-type-col">
-<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
+<a href="yiiunit-apidoc-data-api-classes-generictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                             <td class="param-desc-col">
                                                             </td>
                         </tr>
@@ -132,7 +132,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags#getIntWithParams()-detail">getIntWithParams</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$test</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$test2</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$test3</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags#getIntWithParams()-detail">getIntWithParams</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$test</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$test2</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$test3</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span>
 </td></tr>
 
                                                             <tr>
@@ -189,7 +189,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags#getMixedWithoutParams()-detail">getMixedWithoutParams</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags#getMixedWithoutParams()-detail">getMixedWithoutParams</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__18.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__18.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -70,12 +70,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#getNameFromSomeData()-detail">getNameFromSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#getSomeField()-detail">getSomeField()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -110,7 +110,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#getNameFromSomeData()-detail">getNameFromSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#phpstan-type-SomeData">SomeData</a>["name"]</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#getNameFromSomeData()-detail">getNameFromSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#phpstan-type-SomeData">SomeData</a>["name"]</span>
 </td></tr>
 
                             </table>
@@ -155,7 +155,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#getSomeField()-detail">getSomeField</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><span style="color: #0000BB">$array</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes#getSomeField()-detail">getSomeField</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><span style="color: #0000BB">$array</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__19.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__19.html
@@ -13,7 +13,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -51,115 +51,115 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24arrayKey-detail">$arrayKey</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24callableArray-detail">$callableArray</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#callable-arrays">callable-array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24callableString-detail">$callableString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">callable-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24closedResource-detail">$closedResource</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">closed-resource</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24enumString-detail">$enumString</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#enum-string">enum-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24literalString-detail">$literalString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">literal-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24lowercaseString-detail">$lowercaseString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">lowercase-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24negativeInt-detail">$negativeInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">negative-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24nonEmptyString-detail">$nonEmptyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">non-empty-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24nonFalsyString-detail">$nonFalsyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">non-falsy-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24nonNegativeInt-detail">$nonNegativeInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-negative-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24nonPositiveInt-detail">$nonPositiveInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-positive-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24nonZeroInt-detail">$nonZeroInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-zero-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24numericString-detail">$numericString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">numeric-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24openResource-detail">$openResource</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">open-resource</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24positiveInt-detail">$positiveInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">positive-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24scalar-detail">$scalar</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">scalar</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24traitString-detail">$traitString</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#trait-string">trait-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#%24truthyString-detail">$truthyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">truthy-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -186,32 +186,32 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#getFalse()-detail">getFalse()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#getThis()-detail">getThis()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#getTrue()-detail">getTrue()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#neverReturn()-detail">neverReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#neverReturns()-detail">neverReturns()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes#noReturn()-detail">noReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -690,7 +690,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes#getFalse()-detail">getFalse</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">false</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes#getFalse()-detail">getFalse</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">false</a></span>
 </td></tr>
 
                             </table>
@@ -735,7 +735,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes#getThis()-detail">getThis</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-othertypes">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes#getThis()-detail">getThis</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-othertypes">$this</a></span>
 </td></tr>
 
                             </table>
@@ -780,7 +780,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes#getTrue()-detail">getTrue</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">true</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes#getTrue()-detail">getTrue</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">true</a></span>
 </td></tr>
 
                             </table>
@@ -825,7 +825,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes#neverReturn()-detail">neverReturn</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-return</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes#neverReturn()-detail">neverReturn</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-return</a></span>
 </td></tr>
 
                             </table>
@@ -870,7 +870,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes#neverReturns()-detail">neverReturns</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-returns</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes#neverReturns()-detail">neverReturns</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-returns</a></span>
 </td></tr>
 
                             </table>
@@ -915,7 +915,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes#noReturn()-detail">noReturn</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">no-return</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes#noReturn()-detail">noReturn</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">no-return</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__20.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__20.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -48,22 +48,22 @@
 
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags#%24classWrite-detail">$classWrite</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags#%24int-detail">$int</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags#%24intMaskRead-detail">$intMaskRead</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask</a>&lt;1, 2, 4&gt;</td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -98,7 +98,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\apidoc\data\api\classes\PropertyTags</a></span><a href="yiiunit-apidoc-data-api-classes-propertytags#%24classWrite-detail">$classWrite</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-propertytags">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-propertytags#%24classWrite-detail">$classWrite</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__21.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__21.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -102,17 +102,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getOnlyPHPStanType()-detail">getOnlyPHPStanType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getOnlyPsalmType()-detail">getOnlyPsalmType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getSomeData()-detail">getSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -147,7 +147,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
 </td></tr>
 
                             </table>
@@ -192,7 +192,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getOnlyPsalmType()-detail">getOnlyPsalmType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getOnlyPsalmType()-detail">getOnlyPsalmType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
 </td></tr>
 
                             </table>
@@ -237,7 +237,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getSomeData()-detail">getSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-SomeData">SomeData</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes#getSomeData()-detail">getSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-SomeData">SomeData</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__22.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__22.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -49,17 +49,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getOnlyPHPStanType()-detail">getOnlyPHPStanType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getOnlyPsalmType()-detail">getOnlyPsalmType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getSomeData()-detail">getSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -94,7 +94,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
 </td></tr>
 
                             </table>
@@ -139,7 +139,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getOnlyPsalmType()-detail">getOnlyPsalmType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getOnlyPsalmType()-detail">getOnlyPsalmType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
 </td></tr>
 
                             </table>
@@ -184,7 +184,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getSomeData()-detail">getSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-SomeData">SomeData</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports#getSomeData()-detail">getSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes#phpstan-type-SomeData">SomeData</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__23.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__23.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -51,42 +51,42 @@
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{0: <a href="https://www.php.net/language.types.string">string</a>, 1?: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes#%24arrayWithStringKeys-detail">$arrayWithStringKeys</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{name: <a href="https://www.php.net/language.types.string">string</a>, value?: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes#%24arrayWithoutKeys-detail">$arrayWithoutKeys</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes#%24listWithKeys-detail">$listWithKeys</a></td>
                     <td>
 <a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#list-shapes">list</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes#%24listWithoutKeys-detail">$listWithoutKeys</a></td>
                     <td>
 <a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#list-shapes">list</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes#%24object-detail">$object</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#object-shapes">object</a>{name: <a href="https://www.php.net/language.types.string">string</a>, value: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__24.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__24.html
@@ -13,7 +13,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-templates">yiiunit\apidoc\data\api\classes\Templates</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-templates">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -52,7 +52,7 @@
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-templates">yiiunit\apidoc\data\api\classes\Templates</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-templates">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -79,7 +79,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-templates#getSomeField()-detail">getSomeField()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-templates">yiiunit\apidoc\data\api\classes\Templates</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-templates">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -144,7 +144,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-templates#getSomeField()-detail">getSomeField</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-templates#getSomeField()-detail">getSomeField</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__25.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__25.html
@@ -14,7 +14,7 @@
                                 <tr>
 <th>Implemented by</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\apidoc\data\api\classes\AbstractClass</a>, <a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a>, <a href="yiiunit-apidoc-data-api-interfaces-subinterface">yiiunit\apidoc\data\api\interfaces\SubInterface</a>
+<a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-interfaces-subinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                     </table>
@@ -52,7 +52,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -86,7 +86,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -117,7 +117,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__26.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__26.html
@@ -13,7 +13,7 @@
     </colgroup>
                     <tr>
 <th>Extends</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                 </table>
 
@@ -50,7 +50,7 @@
                                     <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -84,7 +84,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>SUB_INTERFACE_CONSTANT</td>
@@ -92,7 +92,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface">yiiunit\apidoc\data\api\interfaces\SubInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -119,14 +119,14 @@
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">yiiunit\apidoc\data\api\interfaces\BaseInterface::baseMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface::baseMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__27.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__27.html
@@ -15,7 +15,7 @@
                                     <tr>
 <th>Implemented by</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 </table>
@@ -54,7 +54,7 @@
                     <td><a href="yiiunit-apidoc-data-api-traits-basetrait#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -81,7 +81,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -115,7 +115,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -176,7 +176,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__28.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__28.html
@@ -12,7 +12,7 @@
     </colgroup>
                         <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                             </table>
 
@@ -49,7 +49,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-traits-childtrait#childTraitMethod()-detail">childTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-childtrait">yiiunit\apidoc\data\api\traits\ChildTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-childtrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>ChildTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -84,7 +84,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-childtrait#childTraitMethod()-detail">childTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-childtrait#childTraitMethod()-detail">childTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__3.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__3.html
@@ -13,16 +13,16 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\apidoc\data\api\classes\AbstractClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                         <tr>
 <th>Subclasses</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                         </table>
@@ -32,8 +32,8 @@
     
     <p>See also:</p>
 <ul>
-<li><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></li>
-<li><a href="yiiunit-apidoc-data-api-interfaces-subinterface">yiiunit\apidoc\data\api\interfaces\SubInterface</a></li>
+<li><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></li>
+<li><a href="yiiunit-apidoc-data-api-interfaces-subinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a></li>
 </ul>
 </div>
 
@@ -79,12 +79,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-abstractclass#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\apidoc\data\api\classes\AbstractClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-abstractclass#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -118,7 +118,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -149,7 +149,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-classes-abstractclass#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-abstractclass">$this</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-classes-abstractclass#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-abstractclass">$this</a></span>
 </td></tr>
 
                             </table>
@@ -188,14 +188,14 @@
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">yiiunit\apidoc\data\api\interfaces\BaseInterface::baseMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface::baseMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__4.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__4.html
@@ -16,21 +16,21 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\apidoc\data\api\classes\AbstractClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                     <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                 <tr>
 <th>Subclasses</th>
-<td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                         <tr>
 <th>Available since version</th>
@@ -43,7 +43,7 @@
     <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when
 an unknown printer took a galley of type and scrambled it to make a type specimen book.</p>
 
-    <p>See also <a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\apidoc\data\api\classes\AbstractClass</a> description.</p>
+    <p>See also <a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a> description.</p>
 </div>
 
 
@@ -75,25 +75,25 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#%24baseClassProperty-detail">$baseClassProperty</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#%24deprecatedBaseClassProperty-detail">$deprecatedBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#%24deprecatedSinceBaseClassProperty-detail">$deprecatedSinceBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -120,52 +120,52 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#__construct()-detail">__construct()</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#deprecatedMethod()-detail">deprecatedMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions()</a></td>
                     <td>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithThrows()-detail">methodWithThrows()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithTodoTag()-detail">methodWithTodoTag()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDescriptions()-detail">methodWithoutDescriptions()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDocBlock()-detail">methodWithoutDocBlock()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -193,24 +193,24 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass#DEPRECATED_EVENT-detail">DEPRECATED_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass#DEPRECATED_SINCE_EVENT-detail">DEPRECATED_SINCE_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass#EVENT-detail">EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -242,7 +242,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>BASE_TRAIT_CONST</td>
@@ -250,7 +250,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>DEPRECATED_CONST</td>
@@ -262,7 +262,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>DEPRECATED_SINCE_CONST</td>
@@ -274,7 +274,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           since version 2.2.0: description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -394,7 +394,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#__construct()-detail">__construct</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;</span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#__construct()-detail">__construct</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;</span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -448,7 +448,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-baseclass">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-baseclass">$this</a></span>
 </td></tr>
 
                             </table>
@@ -493,7 +493,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
@@ -548,14 +548,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">yiiunit\apidoc\data\api\traits\BaseTrait::baseTraitMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait::baseTraitMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -606,7 +606,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#deprecatedMethod()-detail">deprecatedMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#deprecatedMethod()-detail">deprecatedMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -653,7 +653,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -698,7 +698,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithThrows()-detail">methodWithThrows</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithThrows()-detail">methodWithThrows</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     
@@ -751,7 +751,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithTodoTag()-detail">methodWithTodoTag</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithTodoTag()-detail">methodWithTodoTag</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -799,7 +799,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -843,7 +843,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -883,7 +883,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 DEPRECATED_EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
                             <div class="doc-description deprecated">
@@ -908,7 +908,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 DEPRECATED_SINCE_EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
                             <div class="doc-description deprecated">
@@ -933,7 +933,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__5.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__5.html
@@ -14,8 +14,8 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a> &raquo;
-<a href="yii-base-baseobject">yii\base\BaseObject</a>
+<a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yii-base-baseobject">yii\<wbr>base\<wbr>BaseObject</wbr></wbr></a>
 </td>
 </tr>
                                         </table>
@@ -54,13 +54,13 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#%24onlyRead-detail">$onlyRead</a></td>
                     <td><a href="https://www.php.net/language.types.mixed">mixed</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#%24onlyWrite-detail">$onlyWrite</a></td>
                     <td><a href="https://www.php.net/language.types.mixed">mixed</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#%24readableAndWritable-detail">$readableAndWritable</a></td>
@@ -68,7 +68,7 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -95,22 +95,22 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getOnlyRead()-detail">getOnlyRead()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getReadableAndWritable()-detail">getReadableAndWritable()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setOnlyWrite()-detail">setOnlyWrite()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setReadableAndWritable()-detail">setReadableAndWritable()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -142,7 +142,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getOnlyRead()-detail">getOnlyRead</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getOnlyRead()-detail">getOnlyRead</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -164,7 +164,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setOnlyWrite()-detail">setOnlyWrite</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setOnlyWrite()-detail">setOnlyWrite</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -186,7 +186,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getReadableAndWritable()-detail">getReadableAndWritable</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span><br><span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setReadableAndWritable()-detail">setReadableAndWritable</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getReadableAndWritable()-detail">getReadableAndWritable</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span><br><span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setReadableAndWritable()-detail">setReadableAndWritable</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -218,7 +218,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getOnlyRead()-detail">getOnlyRead</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getOnlyRead()-detail">getOnlyRead</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                             </table>
@@ -263,7 +263,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getReadableAndWritable()-detail">getReadableAndWritable</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#getReadableAndWritable()-detail">getReadableAndWritable</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                             </table>
@@ -308,7 +308,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setOnlyWrite()-detail">setOnlyWrite</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setOnlyWrite()-detail">setOnlyWrite</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -361,7 +361,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setReadableAndWritable()-detail">setReadableAndWritable</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass#setReadableAndWritable()-detail">setReadableAndWritable</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__6.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__6.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -50,39 +50,39 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24intDocType-detail">$intDocType</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24intTypeHint-detail">$intTypeHint</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24multidimensionalArray-detail">$multidimensionalArray</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a>[]</td>
+<a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>[]</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24nativeClassDocType-detail">$nativeClassDocType</a></td>
                     <td><a href="https://www.php.net/class.exception">Exception</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24nativeClassTypeHint-detail">$nativeClassTypeHint</a></td>
                     <td><a href="https://www.php.net/class.exception">Exception</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24nullableDocType-detail">$nullableDocType</a></td>
@@ -90,7 +90,7 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24nullableTypeHint-detail">$nullableTypeHint</a></td>
@@ -98,31 +98,31 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24stringDocType-detail">$stringDocType</a></td>
                     <td><a href="https://www.php.net/language.types.string">string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24stringTypeHint-detail">$stringTypeHint</a></td>
                     <td><a href="https://www.php.net/language.types.string">string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24userClassDocType-detail">$userClassDocType</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes#%24userClassTypeHint-detail">$userClassTypeHint</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -203,7 +203,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a>[]</span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24multidimensionalArray-detail">$multidimensionalArray</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>[]</span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24multidimensionalArray-detail">$multidimensionalArray</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -226,7 +226,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -387,7 +387,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24userClassDocType-detail">$userClassDocType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24userClassDocType-detail">$userClassDocType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -410,7 +410,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\apidoc\data\api\classes\BasicTypes</a></span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24userClassTypeHint-detail">$userClassTypeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-basictypes#%24userClassTypeHint-detail">$userClassTypeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__7.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__7.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -49,32 +49,32 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes#advancedCallableDocType()-detail">advancedCallableDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes#advancedClosureDocType()-detail">advancedClosureDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes#callableDocType()-detail">callableDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes#callableTypeHint()-detail">callableTypeHint()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes#closureDocType()-detail">closureDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes#closureTypeHint()-detail">closureTypeHint()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -109,13 +109,13 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes#advancedCallableDocType()-detail">advancedCallableDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes#advancedCallableDocType()-detail">advancedCallableDocType</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
                             <td class="param-name-col"><span style="color: #0000BB">$docType</span></td>
                             <td class="param-type-col">
-<a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
+<a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
 </td>
                             <td class="param-desc-col">
                                                            </td>
@@ -164,13 +164,13 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes#advancedClosureDocType()-detail">advancedClosureDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes#advancedClosureDocType()-detail">advancedClosureDocType</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
                             <td class="param-name-col"><span style="color: #0000BB">$docType</span></td>
                             <td class="param-type-col">
-<a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
+<a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
 </td>
                             <td class="param-desc-col">
                                                            </td>
@@ -219,7 +219,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes#callableDocType()-detail">callableDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes#callableDocType()-detail">callableDocType</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
 </td></tr>
 
                                                             <tr>
@@ -272,7 +272,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes#callableTypeHint()-detail">callableTypeHint</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes#callableTypeHint()-detail">callableTypeHint</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
 </td></tr>
 
                                                             <tr>
@@ -325,7 +325,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes#closureDocType()-detail">closureDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes#closureDocType()-detail">closureDocType</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
 </td></tr>
 
                                                             <tr>
@@ -378,7 +378,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes#closureTypeHint()-detail">closureTypeHint</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes#closureTypeHint()-detail">closureTypeHint</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__8.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__8.html
@@ -16,18 +16,18 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\apidoc\data\api\classes\AbstractClass</a>
+<a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-abstractclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                     <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                             </table>
 
@@ -68,31 +68,31 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#%24baseClassProperty-detail">$baseClassProperty</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#%24childProperty-detail">$childProperty</a></td>
                     <td></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#%24deprecatedBaseClassProperty-detail">$deprecatedBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#%24deprecatedSinceBaseClassProperty-detail">$deprecatedSinceBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -119,57 +119,57 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#__construct()-detail">__construct()</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#childMethod()-detail">childMethod()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#deprecatedMethod()-detail">deprecatedMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions()</a></td>
                     <td>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#methodWithThrows()-detail">methodWithThrows()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#methodWithTodoTag()-detail">methodWithTodoTag()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#methodWithoutDescriptions()-detail">methodWithoutDescriptions()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass#methodWithoutDocBlock()-detail">methodWithoutDocBlock()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -197,24 +197,24 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass#DEPRECATED_EVENT-detail">DEPRECATED_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass#DEPRECATED_SINCE_EVENT-detail">DEPRECATED_SINCE_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass#EVENT-detail">EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -246,7 +246,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>BASE_TRAIT_CONST</td>
@@ -254,7 +254,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>DEPRECATED_CONST</td>
@@ -266,7 +266,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>DEPRECATED_SINCE_CONST</td>
@@ -278,7 +278,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           since version 2.2.0: description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -362,7 +362,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass#__construct()-detail">__construct</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span>, <span class="signature-type"><a href="https://www.php.net/language.types.array">array</a></span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass#__construct()-detail">__construct</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span>, <span class="signature-type"><a href="https://www.php.net/language.types.array">array</a></span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -417,14 +417,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass#abstractMethod()-detail">yiiunit\apidoc\data\api\classes\BaseClass::abstractMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass#abstractMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::abstractMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-childclass">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-childclass">$this</a></span>
 </td></tr>
 
                             </table>
@@ -469,7 +469,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
@@ -525,14 +525,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">yiiunit\apidoc\data\api\traits\BaseTrait::baseTraitMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait::baseTraitMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -576,7 +576,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass#childMethod()-detail">childMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass#childMethod()-detail">childMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"></span>
 </td></tr>
 
                                                             <tr>
@@ -631,14 +631,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass#deprecatedMethod()-detail">yiiunit\apidoc\data\api\classes\BaseClass::deprecatedMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass#deprecatedMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::deprecatedMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#deprecatedMethod()-detail">deprecatedMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#deprecatedMethod()-detail">deprecatedMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -679,7 +679,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithShortAndDetailedDescriptions()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithShortAndDetailedDescriptions()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithShortAndDetailedDescriptions()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithShortAndDetailedDescriptions()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</strong></p>
                     <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when
@@ -688,7 +688,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -729,14 +729,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithThrows()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithThrows()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithThrows()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithThrows()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithThrows()-detail">methodWithThrows</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithThrows()-detail">methodWithThrows</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     
@@ -785,14 +785,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithTodoTag()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithTodoTag()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithTodoTag()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithTodoTag()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithTodoTag()-detail">methodWithTodoTag</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithTodoTag()-detail">methodWithTodoTag</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -837,13 +837,13 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDescriptions()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithoutDescriptions()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDescriptions()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithoutDescriptions()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                             </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -884,13 +884,13 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDocBlock()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithoutDocBlock()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDocBlock()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithoutDocBlock()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                             </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__9.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set online__9.html
@@ -12,7 +12,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -49,18 +49,18 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes#%24docType-detail">$docType</a></td>
                     <td>
-<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\apidoc\data\api\classes\CompoundTypes</a>
+<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes#%24typeHint-detail">$typeHint</a></td>
                     <td>
-<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\apidoc\data\api\classes\CompoundTypes</a>
+<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -95,7 +95,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\apidoc\data\api\classes\CompoundTypes</a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes#%24docType-detail">$docType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes#%24docType-detail">$docType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -118,7 +118,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\apidoc\data\api\classes\CompoundTypes</a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes#%24typeHint-detail">$typeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes#%24typeHint-detail">$typeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__10.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__10.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,12 +122,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditional()-detail">conditional()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditionalForParameter()-detail">conditionalForParameter()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\apidoc\data\api\classes\ConditionalTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ConditionalTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -162,7 +162,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditional()-detail">conditional</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;|<a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditional()-detail">conditional</a>( <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;|<a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -217,7 +217,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditionalForParameter()-detail">conditionalForParameter</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="https://www.php.net/language.types.object">object</a>&gt;</span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-conditionaltypes.html#conditionalForParameter()-detail">conditionalForParameter</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="https://www.php.net/language.types.object">object</a>&gt;</span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.object">object</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__11.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__11.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -84,7 +84,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-emptyclass.html">yiiunit\apidoc\data\api\classes\EmptyClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-emptyclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>EmptyClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__12.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__12.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -84,7 +84,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__13.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__13.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,7 +87,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -124,177 +124,177 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayWithKeyAndValueType-detail">$arrayWithKeyAndValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayWithValueType-detail">$arrayWithValueType</a></td>
                     <td>
 <a href="https://www.php.net/language.types.string">string</a>[]</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayWithoutGenerics-detail">$arrayWithoutGenerics</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithType-detail">$classStringWithType</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithoutType-detail">$classStringWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24intMask-detail">$intMask</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask</a>&lt;1, 2, 4&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24intMaskOf-detail">$intMaskOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask-of</a>&lt;1|2|4&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24intRange-detail">$intRange</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">int</a>&lt;1, max&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithType-detail">$interfaceStringWithType</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithoutType-detail">$interfaceStringWithoutType</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24iterableWithGenerics-detail">$iterableWithGenerics</a></td>
                     <td>
 <a href="https://www.php.net/language.types.iterable">iterable</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24iterableWithoutGenerics-detail">$iterableWithoutGenerics</a></td>
                     <td><a href="https://www.php.net/language.types.iterable">iterable</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24keyOf-detail">$keyOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#key-and-value-types-of-arrays-and-iterables">key-of</a>&lt;self::COLORS&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24listWithType-detail">$listWithType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">list</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24listWithoutType-detail">$listWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">list</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyArrayWithKeyAndValueType-detail">$nonEmptyArrayWithKeyAndValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyArrayWithValueType-detail">$nonEmptyArrayWithValueType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyArrayWithoutGenerics-detail">$nonEmptyArrayWithoutGenerics</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">non-empty-array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyListWithType-detail">$nonEmptyListWithType</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">non-empty-list</a>&lt;<a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24nonEmptyListWithoutType-detail">$nonEmptyListWithoutType</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#lists">non-empty-list</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24privatePropertiesOf-detail">$privatePropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24propertiesOf-detail">$propertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24publicPropertiesOf-detail">$publicPropertiesOf</a></td>
                     <td>
-<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</td>
+<a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24valueOf-detail">$valueOf</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#key-and-value-types-of-arrays-and-iterables">value-of</a>&lt;self::COLORS&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -321,27 +321,27 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getClassWithGenerics()-detail">getClassWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithGenerics()-detail">getSelfWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithGenerics()-detail">getStaticWithGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -378,7 +378,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>COLOR_GREY</td>
@@ -386,7 +386,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>COLOR_WHITE</td>
@@ -394,7 +394,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -423,7 +423,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24arrayOfGenericClasses-detail">$arrayOfGenericClasses</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -515,7 +515,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithType-detail">$classStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#class-string">class-string</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24classStringWithType-detail">$classStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -630,7 +630,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithType-detail">$interfaceStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string">interface-string</a>&lt;<a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24interfaceStringWithType-detail">$interfaceStringWithType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -906,7 +906,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24privatePropertiesOf-detail">$privatePropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">private-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24privatePropertiesOf-detail">$privatePropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -929,7 +929,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24propertiesOf-detail">$propertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24propertiesOf-detail">$propertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -952,7 +952,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">protected-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24protectedPropertiesOf-detail">$protectedPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -975,7 +975,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24publicPropertiesOf-detail">$publicPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://psalm.dev/docs/annotating_code/type_syntax/utility_types/#properties-oft">public-properties-of</a>&lt;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#%24publicPropertiesOf-detail">$publicPropertiesOf</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -1030,7 +1030,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getClassWithGenerics()-detail">getClassWithGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getClassWithGenerics()-detail">getClassWithGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1075,7 +1075,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithGenerics()-detail">getSelfWithGenerics</a></strong>( ): <span class="signature-type">self&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithGenerics()-detail">getSelfWithGenerics</a>( ): <span class="signature-type">self&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1120,7 +1120,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics</a></strong>( ): <span class="signature-type">self</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getSelfWithoutGenerics()-detail">getSelfWithoutGenerics</a>( ): <span class="signature-type">self</span>
 </td></tr>
 
                             </table>
@@ -1165,7 +1165,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithGenerics()-detail">getStaticWithGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithGenerics()-detail">getStaticWithGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/class.exception">Exception</a>&gt;</span>
 </td></tr>
 
                             </table>
@@ -1210,7 +1210,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-generictypes.html#getStaticWithoutGenerics()-detail">getStaticWithoutGenerics</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__14.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__14.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,7 +87,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -125,7 +125,7 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#%24someProperty-detail">$someProperty</a></td>
                     <td></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -152,17 +152,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#guideLink()-detail">guideLink()</a></td>
                     <td>See the <a href="/guide-concept-aliases.html#defining-aliases">aliases section</a> of the guide.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">inlineLink()</a></td>
                     <td>Some description. See <a href="https://docs.phpdoc.org/guide/references/phpdoc/tags/link.html">documentation</a>.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineSee()-detail">inlineSee()</a></td>
                     <td>Some description. See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">parent method</a>.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -196,7 +196,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -257,7 +257,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#guideLink()-detail">guideLink</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#guideLink()-detail">guideLink</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -304,7 +304,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">inlineLink</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">inlineLink</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -345,12 +345,12 @@
             <div class="doc-description">
                 
                                     <p><strong>Some description. See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">parent method</a>.</strong></p>
-                    <p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#SOME_CONST-detail">yiiunit\apidoc\data\api\classes\InlineTags::SOME_CONST</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#%24someProperty-detail">yiiunit\apidoc\data\api\classes\InlineTags::$someProperty</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>.</p>
+                    <p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#SOME_CONST-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::SOME_CONST</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#%24someProperty-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::$someProperty</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>.</p>
 <p>See <a href="https://www.php.net/manual/intro.filter.php">documentation</a>.</p>
-<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">yiiunit\apidoc\data\api\classes\InlineTags::inlineLink()</a>.</p>
+<p>See <a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineLink()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags::inlineLink()</wbr></wbr></wbr></wbr></wbr></a>.</p>
 <p>See <a href="https://www.php.net/class.arrayaccess">ArrayAccess</a>.</p>
 <p>See <a href="https://www.php.net/manual/en/function.in-array.php">in_array()</a>.</p>
 <p>See <a href="https://www.php.net/manual/en/function.in-array.php">in_array()</a>.</p>
@@ -360,7 +360,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineSee()-detail">inlineSee</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-inlinetags.html#inlineSee()-detail">inlineSee</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__15.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__15.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,17 +122,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24basic-detail">$basic</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a>
+<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24withGenerics-detail">$withGenerics</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
+<a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -167,7 +167,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\apidoc\data\api\classes\InlineTags</a></span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24basic-detail">$basic</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-inlinetags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InlineTags</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24basic-detail">$basic</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -190,7 +190,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\apidoc\data\api\classes\IntersectionTypes</a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24withGenerics-detail">$withGenerics</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>IntersectionTypes</wbr></wbr></wbr></wbr></wbr></a>&amp;<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-intersectiontypes.html#%24withGenerics-detail">$withGenerics</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__16.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__16.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -125,7 +125,7 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#%24invalidVar-detail">$invalidVar</a></td>
                     <td></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -152,7 +152,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#invalidParamAndReturn()-detail">invalidParamAndReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\apidoc\data\api\classes\InvalidTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-invalidtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>InvalidTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -216,7 +216,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#invalidParamAndReturn()-detail">invalidParamAndReturn</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-invalidtags.html#invalidParamAndReturn()-detail">invalidParamAndReturn</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__17.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__17.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,17 +122,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getGenericTypes()-detail">getGenericTypes()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getIntWithParams()-detail">getIntWithParams()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getMixedWithoutParams()-detail">getMixedWithoutParams()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\apidoc\data\api\classes\MethodTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-methodtags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>MethodTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -167,14 +167,14 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getGenericTypes()-detail">getGenericTypes</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getGenericTypes()-detail">getGenericTypes</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span>
 </td></tr>
 
                                     
                                             <tr>
                             <th class="param-name-col">return</th>
                             <td class="param-type-col">
-<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\apidoc\data\api\classes\GenericTypes</a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
+<a href="yiiunit-apidoc-data-api-classes-generictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>GenericTypes</wbr></wbr></wbr></wbr></wbr></a>&lt;<a href="https://www.php.net/language.types.integer">integer</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</td>
                             <td class="param-desc-col">
                                                             </td>
                         </tr>
@@ -205,7 +205,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getIntWithParams()-detail">getIntWithParams</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$test</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$test2</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$test3</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getIntWithParams()-detail">getIntWithParams</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$test</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$test2</span>, <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$test3</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span>
 </td></tr>
 
                                                             <tr>
@@ -262,7 +262,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getMixedWithoutParams()-detail">getMixedWithoutParams</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-methodtags.html#getMixedWithoutParams()-detail">getMixedWithoutParams</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__18.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__18.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -143,12 +143,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getNameFromSomeData()-detail">getNameFromSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getSomeField()-detail">getSomeField()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\apidoc\data\api\classes\OffsetAccessTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OffsetAccessTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -183,7 +183,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getNameFromSomeData()-detail">getNameFromSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#phpstan-type-SomeData">SomeData</a>["name"]</span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getNameFromSomeData()-detail">getNameFromSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#phpstan-type-SomeData">SomeData</a>["name"]</span>
 </td></tr>
 
                             </table>
@@ -228,7 +228,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getSomeField()-detail">getSomeField</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><span style="color: #0000BB">$array</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-offsetaccesstypes.html#getSomeField()-detail">getSomeField</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.string">string</a>&gt;</span><span style="color: #0000BB">$array</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__19.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__19.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -124,115 +124,115 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24arrayKey-detail">$arrayKey</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24callableArray-detail">$callableArray</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#callable-arrays">callable-array</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24callableString-detail">$callableString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">callable-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24closedResource-detail">$closedResource</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">closed-resource</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24enumString-detail">$enumString</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#enum-string">enum-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24literalString-detail">$literalString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">literal-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24lowercaseString-detail">$lowercaseString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">lowercase-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24negativeInt-detail">$negativeInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">negative-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonEmptyString-detail">$nonEmptyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">non-empty-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonFalsyString-detail">$nonFalsyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">non-falsy-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonNegativeInt-detail">$nonNegativeInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-negative-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonPositiveInt-detail">$nonPositiveInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-positive-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24nonZeroInt-detail">$nonZeroInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">non-zero-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24numericString-detail">$numericString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">numeric-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24openResource-detail">$openResource</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">open-resource</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24positiveInt-detail">$positiveInt</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges">positive-int</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24scalar-detail">$scalar</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">scalar</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24traitString-detail">$traitString</a></td>
                     <td><a href="https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#trait-string">trait-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#%24truthyString-detail">$truthyString</a></td>
                     <td><a href="https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types">truthy-string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -259,32 +259,32 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getFalse()-detail">getFalse()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getThis()-detail">getThis()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getTrue()-detail">getTrue()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturn()-detail">neverReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturns()-detail">neverReturns()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html#noReturn()-detail">noReturn()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\apidoc\data\api\classes\OtherTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-othertypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>OtherTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -763,7 +763,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getFalse()-detail">getFalse</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">false</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getFalse()-detail">getFalse</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">false</a></span>
 </td></tr>
 
                             </table>
@@ -808,7 +808,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getThis()-detail">getThis</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-othertypes.html">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getThis()-detail">getThis</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-othertypes.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -853,7 +853,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getTrue()-detail">getTrue</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">true</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#getTrue()-detail">getTrue</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.boolean">true</a></span>
 </td></tr>
 
                             </table>
@@ -898,7 +898,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturn()-detail">neverReturn</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-return</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturn()-detail">neverReturn</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-return</a></span>
 </td></tr>
 
                             </table>
@@ -943,7 +943,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturns()-detail">neverReturns</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-returns</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#neverReturns()-detail">neverReturns</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">never-returns</a></span>
 </td></tr>
 
                             </table>
@@ -988,7 +988,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-othertypes.html#noReturn()-detail">noReturn</a></strong>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">no-return</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-othertypes.html#noReturn()-detail">noReturn</a>( ): <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#bottom-type">no-return</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__20.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__20.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -121,22 +121,22 @@
 
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24classWrite-detail">$classWrite</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24int-detail">$int</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24intMaskRead-detail">$intMaskRead</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#integer-masks">int-mask</a>&lt;1, 2, 4&gt;</td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -171,7 +171,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\apidoc\data\api\classes\PropertyTags</a></span><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24classWrite-detail">$classWrite</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-propertytags.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PropertyTags</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-propertytags.html#%24classWrite-detail">$classWrite</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__21.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__21.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -175,17 +175,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPsalmType()-detail">getOnlyPsalmType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getSomeData()-detail">getSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\apidoc\data\api\classes\PseudoTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -220,7 +220,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
 </td></tr>
 
                             </table>
@@ -265,7 +265,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
 </td></tr>
 
                             </table>
@@ -310,7 +310,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getSomeData()-detail">getSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#getSomeData()-detail">getSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__22.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__22.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,17 +122,17 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPsalmType()-detail">getOnlyPsalmType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getSomeData()-detail">getSomeData()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\apidoc\data\api\classes\PseudoTypesImports</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>PseudoTypesImports</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -167,7 +167,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPHPStanType()-detail">getOnlyPHPStanType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-OnlyPHPStanType">OnlyPHPStanType</a></span>
 </td></tr>
 
                             </table>
@@ -212,7 +212,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getOnlyPsalmType()-detail">getOnlyPsalmType</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#psalm-type-OnlyPsalmType">OnlyPsalmType</a></span>
 </td></tr>
 
                             </table>
@@ -257,7 +257,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getSomeData()-detail">getSomeData</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-pseudotypesimports.html#getSomeData()-detail">getSomeData</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-pseudotypes.html#phpstan-type-SomeData">SomeData</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__23.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__23.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -124,42 +124,42 @@
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{0: <a href="https://www.php.net/language.types.string">string</a>, 1?: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24arrayWithStringKeys-detail">$arrayWithStringKeys</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{name: <a href="https://www.php.net/language.types.string">string</a>, value?: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24arrayWithoutKeys-detail">$arrayWithoutKeys</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#array-shapes">array</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24listWithKeys-detail">$listWithKeys</a></td>
                     <td>
 <a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#list-shapes">list</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24listWithoutKeys-detail">$listWithoutKeys</a></td>
                     <td>
 <a href="https://psalm.dev/docs/annotating_code/type_syntax/array_types/#list-shapes">list</a>{<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html#%24object-detail">$object</a></td>
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#object-shapes">object</a>{name: <a href="https://www.php.net/language.types.string">string</a>, value: <a href="https://www.php.net/language.types.mixed">mixed</a>}</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\apidoc\data\api\classes\ShapeTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-shapetypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ShapeTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__24.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__24.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\apidoc\data\api\classes\Templates</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -125,7 +125,7 @@
                     <td>
 <a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\apidoc\data\api\classes\Templates</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -152,7 +152,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-templates.html#getSomeField()-detail">getSomeField()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\apidoc\data\api\classes\Templates</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-templates.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Templates</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -217,7 +217,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-templates.html#getSomeField()-detail">getSomeField</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-templates.html#getSomeField()-detail">getSomeField</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#basic-types">array-key</a></span><span style="color: #0000BB">$key</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__25.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__25.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,7 +87,7 @@
                                 <tr>
 <th>Implemented by</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a>, <a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a>, <a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\apidoc\data\api\interfaces\SubInterface</a>
+<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                     </table>
@@ -125,7 +125,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -159,7 +159,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -190,7 +190,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__26.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__26.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,7 +86,7 @@
     </colgroup>
                     <tr>
 <th>Extends</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                 </table>
 
@@ -123,7 +123,7 @@
                                     <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -157,7 +157,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>SUB_INTERFACE_CONSTANT</td>
@@ -165,7 +165,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\apidoc\data\api\interfaces\SubInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -192,14 +192,14 @@
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\apidoc\data\api\interfaces\BaseInterface::baseMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface::baseMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__27.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__27.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -88,7 +88,7 @@
                                     <tr>
 <th>Implemented by</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 </table>
@@ -127,7 +127,7 @@
                     <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -154,7 +154,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -188,7 +188,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -249,7 +249,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__28.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__28.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
                         <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                             </table>
 
@@ -122,7 +122,7 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-traits-childtrait.html#childTraitMethod()-detail">childTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-childtrait.html">yiiunit\apidoc\data\api\traits\ChildTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-childtrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>ChildTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -157,7 +157,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-childtrait.html#childTraitMethod()-detail">childTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-childtrait.html#childTraitMethod()-detail">childTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__3.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__3.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -86,16 +86,16 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                         <tr>
 <th>Subclasses</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a>, <a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                         </table>
@@ -105,8 +105,8 @@
     
     <p>See also:</p>
 <ul>
-<li><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></li>
-<li><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\apidoc\data\api\interfaces\SubInterface</a></li>
+<li><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></li>
+<li><a href="yiiunit-apidoc-data-api-interfaces-subinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>SubInterface</wbr></wbr></wbr></wbr></wbr></a></li>
 </ul>
 </div>
 
@@ -152,12 +152,12 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -191,7 +191,7 @@
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -222,7 +222,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">$this</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-classes-abstractclass.html#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-abstractclass.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -261,14 +261,14 @@
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\apidoc\data\api\interfaces\BaseInterface::baseMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface::baseMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public abstract</span><strong><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public abstract</span><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__4.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__4.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -89,21 +89,21 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a>
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                     <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                 <tr>
 <th>Subclasses</th>
-<td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                         <tr>
 <th>Available since version</th>
@@ -116,7 +116,7 @@
     <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when
 an unknown printer took a galley of type and scrambled it to make a type specimen book.</p>
 
-    <p>See also <a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a> description.</p>
+    <p>See also <a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a> description.</p>
 </div>
 
 
@@ -148,25 +148,25 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24baseClassProperty-detail">$baseClassProperty</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24deprecatedBaseClassProperty-detail">$deprecatedBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24deprecatedSinceBaseClassProperty-detail">$deprecatedSinceBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -193,52 +193,52 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#__construct()-detail">__construct()</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions()</a></td>
                     <td>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -266,24 +266,24 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#DEPRECATED_EVENT-detail">DEPRECATED_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#DEPRECATED_SINCE_EVENT-detail">DEPRECATED_SINCE_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
                 <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html#EVENT-detail">EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -315,7 +315,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>BASE_TRAIT_CONST</td>
@@ -323,7 +323,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>DEPRECATED_CONST</td>
@@ -335,7 +335,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="">
               <td>DEPRECATED_SINCE_CONST</td>
@@ -347,7 +347,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           since version 2.2.0: description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -467,7 +467,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#__construct()-detail">__construct</a></strong>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;</span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#__construct()-detail">__construct</a>( <span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.mixed">mixed</a>&gt;</span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -521,7 +521,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-baseclass.html">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-baseclass.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -566,7 +566,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
@@ -621,14 +621,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\apidoc\data\api\traits\BaseTrait::baseTraitMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait::baseTraitMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -679,7 +679,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -726,7 +726,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -771,7 +771,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     
@@ -824,7 +824,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -872,7 +872,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -916,7 +916,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -956,7 +956,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 DEPRECATED_EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
                             <div class="doc-description deprecated">
@@ -981,7 +981,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 DEPRECATED_SINCE_EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
                             <div class="doc-description deprecated">
@@ -1006,7 +1006,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                 EVENT
                 <span class="detail-header-tag small">
                     event of type
-                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a>                                    </span>
+                    <a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a>                                    </span>
             </div>
 
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__5.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__5.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item active" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -87,8 +87,8 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a> &raquo;
-<a href="yii-base-baseobject.html">yii\base\BaseObject</a>
+<a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yii-base-baseobject.html">yii\<wbr>base\<wbr>BaseObject</wbr></wbr></a>
 </td>
 </tr>
                                         </table>
@@ -127,13 +127,13 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#%24onlyRead-detail">$onlyRead</a></td>
                     <td><a href="https://www.php.net/language.types.mixed">mixed</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#%24onlyWrite-detail">$onlyWrite</a></td>
                     <td><a href="https://www.php.net/language.types.mixed">mixed</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#%24readableAndWritable-detail">$readableAndWritable</a></td>
@@ -141,7 +141,7 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -168,22 +168,22 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\apidoc\data\api\classes\BaseObjectChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseObjectChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -215,7 +215,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -237,7 +237,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -259,7 +259,7 @@
                                             </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span><br><span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span><br><span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </div>
             
             
@@ -291,7 +291,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getOnlyRead()-detail">getOnlyRead</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                             </table>
@@ -336,7 +336,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#getReadableAndWritable()-detail">getReadableAndWritable</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a></span>
 </td></tr>
 
                             </table>
@@ -381,7 +381,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setOnlyWrite()-detail">setOnlyWrite</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -434,7 +434,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseobjectchildclass.html#setReadableAndWritable()-detail">setReadableAndWritable</a>( <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$name</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__6.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__6.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -123,39 +123,39 @@
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24intDocType-detail">$intDocType</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24intTypeHint-detail">$intTypeHint</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArray-detail">$multidimensionalArray</a></td>
                     <td>
-<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>[]</td>
+<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>[]</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a></td>
                     <td>
-<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</td>
+<a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nativeClassDocType-detail">$nativeClassDocType</a></td>
                     <td><a href="https://www.php.net/class.exception">Exception</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nativeClassTypeHint-detail">$nativeClassTypeHint</a></td>
                     <td><a href="https://www.php.net/class.exception">Exception</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nullableDocType-detail">$nullableDocType</a></td>
@@ -163,7 +163,7 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24nullableTypeHint-detail">$nullableTypeHint</a></td>
@@ -171,31 +171,31 @@
 <a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24stringDocType-detail">$stringDocType</a></td>
                     <td><a href="https://www.php.net/language.types.string">string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24stringTypeHint-detail">$stringTypeHint</a></td>
                     <td><a href="https://www.php.net/language.types.string">string</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassDocType-detail">$userClassDocType</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassTypeHint-detail">$userClassTypeHint</a></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -276,7 +276,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>[]</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArray-detail">$multidimensionalArray</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>[]</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArray-detail">$multidimensionalArray</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -299,7 +299,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://phpstan.org/writing-php-code/phpdoc-types#general-arrays">array</a>&lt;<a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a>|<a href="https://www.php.net/language.types.integer">integer</a>&gt;</span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24multidimensionalArrayWithUnion-detail">$multidimensionalArrayWithUnion</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -460,7 +460,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassDocType-detail">$userClassDocType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassDocType-detail">$userClassDocType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -483,7 +483,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\apidoc\data\api\classes\BasicTypes</a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassTypeHint-detail">$userClassTypeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-basictypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BasicTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-basictypes.html#%24userClassTypeHint-detail">$userClassTypeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__7.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__7.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,32 +122,32 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedCallableDocType()-detail">advancedCallableDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedClosureDocType()-detail">advancedClosureDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableDocType()-detail">callableDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableTypeHint()-detail">callableTypeHint()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureDocType()-detail">closureDocType()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureTypeHint()-detail">closureTypeHint()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -182,13 +182,13 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedCallableDocType()-detail">advancedCallableDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedCallableDocType()-detail">advancedCallableDocType</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
                             <td class="param-name-col"><span style="color: #0000BB">$docType</span></td>
                             <td class="param-type-col">
-<a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
+<a href="https://www.php.net/language.types.callable">callable</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
 </td>
                             <td class="param-desc-col">
                                                            </td>
@@ -237,13 +237,13 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedClosureDocType()-detail">advancedClosureDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#advancedClosureDocType()-detail">advancedClosureDocType</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
                             <td class="param-name-col"><span style="color: #0000BB">$docType</span></td>
                             <td class="param-type-col">
-<a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\apidoc\data\api\classes\CallableTypes</a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
+<a href="https://www.php.net/class.closure">Closure</a>(<a href="https://www.php.net/language.types.string">string</a>, <a href="https://www.php.net/language.types.integer">integer</a> &amp;...$a=, <a href="yiiunit-apidoc-data-api-classes-callabletypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CallableTypes</wbr></wbr></wbr></wbr></wbr></a> &amp;...=): <a href="https://www.php.net/language.types.void">void</a>
 </td>
                             <td class="param-desc-col">
                                                            </td>
@@ -292,7 +292,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableDocType()-detail">callableDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableDocType()-detail">callableDocType</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
 </td></tr>
 
                                                             <tr>
@@ -345,7 +345,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableTypeHint()-detail">callableTypeHint</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#callableTypeHint()-detail">callableTypeHint</a>( <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.callable">callable</a></span>
 </td></tr>
 
                                                             <tr>
@@ -398,7 +398,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureDocType()-detail">closureDocType</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureDocType()-detail">closureDocType</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$docType</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
 </td></tr>
 
                                                             <tr>
@@ -451,7 +451,7 @@
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureTypeHint()-detail">closureTypeHint</a></strong>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-callabletypes.html#closureTypeHint()-detail">closureTypeHint</a>( <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span><span style="color: #0000BB">$typeHint</span> ): <span class="signature-type"><a href="https://www.php.net/class.closure">Closure</a></span>
 </td></tr>
 
                                                             <tr>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__8.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__8.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -89,18 +89,18 @@
             <tr>
 <th>Inheritance</th>
 <td>
-<a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a> &raquo;
-<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\apidoc\data\api\classes\AbstractClass</a>
+<a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a> &raquo;
+<a href="yiiunit-apidoc-data-api-classes-abstractclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>AbstractClass</wbr></wbr></wbr></wbr></wbr></a>
 </td>
 </tr>
                 <tr>
 <th>Implements</th>
-<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+<td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                     <tr>
 <th>Uses Traits</th>
-<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+<td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                             </table>
 
@@ -141,31 +141,31 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24baseClassProperty-detail">$baseClassProperty</a></td>
                     <td><a href="https://www.php.net/language.types.array">array</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24childProperty-detail">$childProperty</a></td>
                     <td></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24deprecatedBaseClassProperty-detail">$deprecatedBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24deprecatedSinceBaseClassProperty-detail">$deprecatedSinceBaseClassProperty</a></td>
                     <td></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#%24traitProp-detail">$traitProp</a></td>
                     <td><a href="https://www.php.net/language.types.integer">integer</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -192,57 +192,57 @@ an unknown printer took a galley of type and scrambled it to make a type specime
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#__construct()-detail">__construct()</a></td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#abstractMethod()-detail">abstractMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseMethod()-detail">baseMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseTraitMethod()-detail">baseTraitMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#childMethod()-detail">childMethod()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\apidoc\data\api\classes\ChildClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-childclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>ChildClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#deprecatedMethod()-detail">deprecatedMethod()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions()</a></td>
                     <td>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithThrows()-detail">methodWithThrows()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithTodoTag()-detail">methodWithTodoTag()</a></td>
                     <td>Description.</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="inherited">
                     <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock()</a></td>
                     <td></td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -270,24 +270,24 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#DEPRECATED_EVENT-detail">DEPRECATED_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#DEPRECATED_SINCE_EVENT-detail">DEPRECATED_SINCE_EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
                 <td><a href="yiiunit-apidoc-data-api-classes-childclass.html#EVENT-detail">EVENT</a></td>
-                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\apidoc\data\api\classes\Event</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-event.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>Event</wbr></wbr></wbr></wbr></wbr></a></td>
                 <td>
                     Description.                                    </td>
-                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+                <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -319,7 +319,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\apidoc\data\api\interfaces\BaseInterface</a></td>
+              <td><a href="yiiunit-apidoc-data-api-interfaces-baseinterface.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces\<wbr>BaseInterface</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>BASE_TRAIT_CONST</td>
@@ -327,7 +327,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
               <td>
                   
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\apidoc\data\api\traits\BaseTrait</a></td>
+              <td><a href="yiiunit-apidoc-data-api-traits-basetrait.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>DEPRECATED_CONST</td>
@@ -339,7 +339,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
                     <tr class="inherited">
               <td>DEPRECATED_SINCE_CONST</td>
@@ -351,7 +351,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
                           since version 2.2.0: description                      </strong>
                                 </td>
-              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\apidoc\data\api\classes\BaseClass</a></td>
+              <td><a href="yiiunit-apidoc-data-api-classes-baseclass.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass</wbr></wbr></wbr></wbr></wbr></a></td>
             </tr>
             </table>
 </div>
@@ -435,7 +435,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass.html#__construct()-detail">__construct</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span>, <span class="signature-type"><a href="https://www.php.net/language.types.array">array</a></span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass.html#__construct()-detail">__construct</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span>, <span class="signature-type"><a href="https://www.php.net/language.types.array">array</a></span><span style="color: #0000BB">$config </span><span style="color: #007700">= []</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                                             <tr>
@@ -490,14 +490,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">yiiunit\apidoc\data\api\classes\BaseClass::abstractMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::abstractMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a></strong>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-childclass.html">$this</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#abstractMethod()-detail">abstractMethod</a>( ): <span class="signature-type"><a href="yiiunit-apidoc-data-api-classes-childclass.html">$this</a></span>
 </td></tr>
 
                             </table>
@@ -542,7 +542,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseMethod()-detail">baseMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass.html#baseMethod()-detail">baseMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a></span><span style="color: #0000BB">$firstParam</span>, <span class="signature-type"><a href="https://www.php.net/language.types.string">string</a></span><span style="color: #0000BB">$secondParam</span> ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                                                             <tr>
@@ -598,14 +598,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\apidoc\data\api\traits\BaseTrait::baseTraitMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits\<wbr>BaseTrait::baseTraitMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-traits-basetrait.html#baseTraitMethod()-detail">baseTraitMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -649,7 +649,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-childclass.html#childMethod()-detail">childMethod</a></strong>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-childclass.html#childMethod()-detail">childMethod</a>( <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span><span style="color: #0000BB">$param</span> ): <span class="signature-type"></span>
 </td></tr>
 
                                                             <tr>
@@ -704,14 +704,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">yiiunit\apidoc\data\api\classes\BaseClass::deprecatedMethod()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::deprecatedMethod()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#deprecatedMethod()-detail">deprecatedMethod</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -752,7 +752,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithShortAndDetailedDescriptions()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithShortAndDetailedDescriptions()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</strong></p>
                     <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when
@@ -761,7 +761,7 @@ an unknown printer took a galley of type and scrambled it to make a type specime
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithShortAndDetailedDescriptions()-detail">methodWithShortAndDetailedDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -802,14 +802,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithThrows()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithThrows()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithThrows()-detail">methodWithThrows</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.mixed">mixed</a></span>
 </td></tr>
 
                                     
@@ -858,14 +858,14 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithTodoTag()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithTodoTag()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                     <p><strong>Description.</strong></p>
                                                                 </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithTodoTag()-detail">methodWithTodoTag</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -910,13 +910,13 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithoutDescriptions()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithoutDescriptions()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                             </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDescriptions()-detail">methodWithoutDescriptions</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>
@@ -957,13 +957,13 @@ an unknown printer took a galley of type and scrambled it to make a type specime
             <div class="doc-description">
                                     <p>
                         <strong>Defined in:</strong>
-                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">yiiunit\apidoc\data\api\classes\BaseClass::methodWithoutDocBlock()</a>                    </p>
+                        <a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>BaseClass::methodWithoutDocBlock()</wbr></wbr></wbr></wbr></wbr></a>                    </p>
                 
                                             </div>
 
             <table class="detail-table table table-striped table-bordered table-hover">
                 <tr><td colspan="3" class="signature">
-<span class="signature-defs">public</span><strong><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a></strong>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
+<span class="signature-defs">public</span><a href="yiiunit-apidoc-data-api-classes-baseclass.html#methodWithoutDocBlock()-detail">methodWithoutDocBlock</a>( ): <span class="signature-type"><a href="https://www.php.net/language.types.void">void</a></span>
 </td></tr>
 
                             </table>

--- a/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__9.html
+++ b/tests/commands/__snapshots__/ApiControllerTest__testGenerateHtml with data set project__9.html
@@ -38,7 +38,7 @@
 <div class="row">
     <div class="col-md-3">
                 <div class="list-group">
-<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\classes <b class="caret"></b></a><div class="submenu panel-collapse collapse in">
+<a class="list-group-item active" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse in">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-abstractclass.html">AbstractClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseclass.html">BaseClass</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-baseobjectchildclass.html">BaseObjectChildClass</a>
@@ -62,11 +62,11 @@
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-shapetypes.html">ShapeTypes</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-classes-templates.html">Templates</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\interfaces <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>interfaces <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-baseinterface.html">BaseInterface</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-interfaces-subinterface.html">SubInterface</a>
 </div>
-<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\apidoc\data\api\traits <b class="caret"></b></a><div class="submenu panel-collapse collapse">
+<a class="list-group-item" data-toggle="collapse" data-parent="#navigation">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>traits <b class="caret"></b></wbr></wbr></wbr></wbr></a><div class="submenu panel-collapse collapse">
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-basetrait.html">BaseTrait</a>
 <a class="list-group-item" href="./yiiunit-apidoc-data-api-traits-childtrait.html">ChildTrait</a>
 </div>
@@ -85,7 +85,7 @@
     </colgroup>
             <tr>
 <th>Inheritance</th>
-<td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+<td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
 </tr>
                                         </table>
 
@@ -122,18 +122,18 @@
                                     <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24docType-detail">$docType</a></td>
                     <td>
-<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a>
+<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                                                 <tr class="">
                     <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24typeHint-detail">$typeHint</a></td>
                     <td>
-<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a>
+<a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a>
 </td>
                     <td>Description</td>
-                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></td>
+                    <td><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></td>
                 </tr>
                         </table>
 </div>
@@ -168,7 +168,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24docType-detail">$docType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24docType-detail">$docType</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             
@@ -191,7 +191,7 @@
                                                                 </div>
 
             <div class="signature">
-<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\apidoc\data\api\classes\CompoundTypes</a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24typeHint-detail">$typeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
+<span class="signature-defs">public</span><span class="signature-type"><a href="https://www.php.net/language.types.integer">integer</a>|<a href="https://www.php.net/language.types.string">string</a>|<a href="https://www.php.net/language.types.null">null</a>|<a href="https://www.php.net/class.exception">Exception</a>|<a href="yiiunit-apidoc-data-api-classes-compoundtypes.html">yiiunit\<wbr>apidoc\<wbr>data\<wbr>api\<wbr>classes\<wbr>CompoundTypes</wbr></wbr></wbr></wbr></wbr></a></span><a href="yiiunit-apidoc-data-api-classes-compoundtypes.html#%24typeHint-detail">$typeHint</a><span style="color: #0000BB"></span><span style="color: #007700">= </span><span style="color: #0000BB">null</span>
 </div>
             
             


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

<img width="892" height="595" alt="image" src="https://github.com/user-attachments/assets/642de2d4-494c-4a67-afe9-1ff4a8342c32" />

<img width="1185" height="247" alt="image" src="https://github.com/user-attachments/assets/bdda595b-cf68-4436-8f06-ae9b3bcdf8c6" />

